### PR TITLE
Custom object and custom scene addon

### DIFF
--- a/bifacial_radiance/bifacial_radiance.py
+++ b/bifacial_radiance/bifacial_radiance.py
@@ -1130,6 +1130,34 @@ class RadianceObj:
             json.dump(data,configfile)
         
         print('Module {} successfully created'.format(name))
+
+
+    def makeCustomObject(self,name=None, text=None):
+        '''
+        Function for development and experimenting with extraneous objects in the scene.
+        This function creates a name.rad textfile in the objects folder
+        with whatever text that is passed to it.
+        It is up to the user to pass the correct radiance format.
+        For example, to create a box at coordinates 0,0 (with its bottom surface 
+        on the plane z=0),
+        name = 'box'
+        text='! genbox black PVmodule 0.5 0.5 0.5 | xform -t -0.25 -0.25 0'
+        
+        Parameters
+        ------------
+        name: string input to name the module type
+        text = ''    # text used in the radfile to generate the module
+        '''
+        
+        customradfile = os.path.join('objects','%s.rad'%(name) ) # update in 0.2.3 to shorten radnames
+        # py2 and 3 compatible: binary write, encode text first
+        with open(customradfile, 'wb') as f:
+            f.write(text.encode('ascii'))
+            
+        print("\nCustom Object Name", customradfile)
+        self.customradfile = customradfile
+        return customradfile
+
         
     def printModules(self):
         # print available module types by creating a dummy SceneObj
@@ -1185,6 +1213,33 @@ class RadianceObj:
         self.radfiles = [self.sceneRAD]
         
         return self.scene
+
+    def appendtoScene(self, radfile=None, customObject=None, text=''):
+        '''
+        demo.addtoScene(scene.radfile, customObject, text='')
+        Appends to the Scene radfile in \\objects the text command in Radiance lingo
+        created by the user.
+        Useful when using addCustomObject to the scene.
+        
+        TO DO: Add a custom name and replace radfile name 
+        
+        Parameters:
+        ----------------
+        'radfile': directory and name of where .rad scene file is stored
+        customObject: directory and name of custom object .rad file is stored
+        text: command to be appended to the radfile. Do not leave empty spaces at the end.
+
+        Returns:
+        ----------------
+        Nothing, the radfile must already be created and assigned when running this.
+        
+        '''
+        
+        # py2 and 3 compatible: binary write, encode text first
+        text2 = '\n' + text + ' ' + customObject
+        
+        with open(radfile, 'a+') as f:
+            f.write(text2.encode('ascii'))
     
     def makeScene1axis(self, trackerdict=None, moduletype=None, sceneDict=None,  nMods=20, nRows=7, psx=0.01, sensorsy=9, modwanted=None, rowwanted=None, cumulativesky=None):
         '''

--- a/docs/Jan2019 New functionalities examples.ipynb
+++ b/docs/Jan2019 New functionalities examples.ipynb
@@ -34,7 +34,9 @@
     "\n",
     "try:\n",
     "    from bifacial_radiance import *\n",
-    "    print \" Successful import of bifacial_radiance version . \"\n",
+    "    import pkg_resources\n",
+    "    version = pkg_resources.get_distribution(\"bifacial_radiance\").version\n",
+    "    print \" Successful import of bifacial_radiance version {}\".format(version)\n",
     "except ImportError:\n",
     "    raise RuntimeError('bifacial_radiance is required. download distribution')\n",
     "    # Simple example system using Radiance."
@@ -103,7 +105,7 @@
     "\n",
     "#We have a 2-up configuration in portrait. This section helps sort what is the COLLECTOR WIDTH to use.\n",
     "if orientation == 'portrait':\n",
-    "                slope=module_height\n",
+    "                slope=module_length\n",
     "elif orientation == 'landscape':  \n",
     "                slope=module_width\n",
     "collectorwidth = slope*numpanels+gap*(numpanels-1) # If it's 1UP, the gap value will not matter. This is a safety.\n",
@@ -585,7 +587,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/docs/Jan2019 New functionalities examples.ipynb
+++ b/docs/Jan2019 New functionalities examples.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -54,7 +54,7 @@
     "\n",
     "# MakeModule Parameters\n",
     "module_type='my_custom_panel'\n",
-    "module_height = 1.996  # 2-up portrait Longi with 15cm additional gap\n",
+    "module_length = 1.996  # 2-up portrait Longi with 15cm additional gap\n",
     "module_width = 0.991\n",
     "orientation='portrait' \n",
     "tilt = 10\n",
@@ -74,7 +74,7 @@
     "clearance_height = 2.35   \n",
     "azimuth_ang=90\n",
     "sensorsy = 200 # Notice we will be doing 200 sensors! It takes more time but gives better resolution.\n",
-    "    "
+    "psx = 0.05"
    ]
   },
   {
@@ -99,7 +99,7 @@
     "demo.setGround(0.62) # input albedo number or material name like 'concrete'.  To see options, run this without any input.\n",
     "epwfile = demo.getEPW(37.5,-77.6) # pull TMY data for any global lat/lon\n",
     "metdata = demo.readEPW(epwfile) # read in the EPW weather data from above\n",
-    "demo.gendaylit2(metdata,4020)  # Noon, June 17th\n",
+    "demo.gendaylit(metdata,4020)  # Noon, June 17th\n",
     "\n",
     "#We have a 2-up configuration in portrait. This section helps sort what is the COLLECTOR WIDTH to use.\n",
     "if orientation == 'portrait':\n",
@@ -109,12 +109,12 @@
     "collectorwidth = slope*numpanels+gap*(numpanels-1) # If it's 1UP, the gap value will not matter. This is a safety.\n",
     "\n",
     "# Making module with all the variables\n",
-    "demo.makeModule(name=module_type,x=module_height,y=module_width,bifi=1,orientation='portrait', \n",
-    "           torquetube=torqueTube, diameter = diameter, tubetype = tubetype, material = torqueTubeMaterial, tubeZgap = disttopanel, numpanels = numpanels, panelgap = gap, rewriteModulefile = True)\n",
+    "demo.makeModule(name=module_type,x=module_width,y=module_length,bifi=1,orientation='portrait', \n",
+    "           torquetube=torqueTube, diameter = diameter, tubetype = tubetype, material = torqueTubeMaterial, tubeZgap = disttopanel, numpanels = numpanels, panelgap = gap, rewriteModulefile = True, psx=psx)\n",
     "# create a scene with all the variables\n",
     "sceneDict = {'tilt':tilt,'pitch': np.round(collectorwidth / gcr,3),'height':clearance_height,'orientation':orientation,'azimuth':azimuth_ang, 'module_type':module_type}  \n",
     "\n",
-    "scene = demo.makeScene(moduletype=module_type, sceneDict=sceneDict, nMods = 20, nRows = 7, sensorsy = sensorsy) #makeScene creates a .rad file with 20 modules per row, 7 rows.\n",
+    "scene = demo.makeScene(moduletype=module_type, sceneDict=sceneDict, nMods = 20, nRows = 7, sensorsy = sensorsy, psx = psx) #makeScene creates a .rad file with 20 modules per row, 7 rows.\n",
     "octfile = demo.makeOct(demo.getfilelist())  # makeOct combines all of the ground, sky and object files into a .oct file.\n"
    ]
   },
@@ -171,7 +171,7 @@
     "\n",
     "# MakeModule Parameters\n",
     "module_type='my_little_pony_panel'\n",
-    "module_height = 1.996  # 2-up portrait Longi with 15cm additional gap\n",
+    "module_length = 1.996  # 2-up portrait Longi with 15cm additional gap\n",
     "module_width = 0.991\n",
     "orientation='portrait' \n",
     "tilt = 10\n",
@@ -210,9 +210,9 @@
     "demo2.setGround(albedo) # input albedo number or material name like 'concrete'.  To see options, run this without any input.\n",
     "epwfile = demo2.getEPW(37.5,-77.6) # pull TMY data for any global lat/lon\n",
     "metdata = demo2.readEPW(epwfile) # read in the weather data\n",
-    "demo2.gendaylit2(metdata, 4020)  # Noon, June 17th\n",
+    "demo2.gendaylit(metdata, 4020)  # Noon, June 17th\n",
     "\n",
-    "demo2.makeModule(name=module_type,x=module_width,y=module_height)    \n",
+    "demo2.makeModule(name=module_type,x=module_width,y=module_length)    \n",
     "tracker_theta, tracker_height, azimuth_ang = demo2._getTrackingGeometryTimeIndex(metdata, timeindex=timeindex, angledelta = angledelta, roundTrackerAngleBool = roundTrackerAngleBool, axis_azimuth = axis_azimuth, limit_angle = limit_angle, backtrack = backtrack, gcr = gcr, hubheight = hub_height, module_height = module_height )\n",
     "sceneDict = {'tilt':tracker_theta,'pitch': module_height / gcr,'height':tracker_height,'orientation':orientation,'azimuth':azimuth_ang, 'module_type':module_type}  \n",
     "scene = demo2.makeScene(module_type, sceneDict) #makeScene creates a .rad file with 20 modules per row, 7 rows.\n",
@@ -248,6 +248,204 @@
     "After you set up your system parameters, you can just change the timestamp and evaluate any day. You could also use gendaylit2manual to pass specific DNI/DHI if you so wanted.\n",
     "\n",
     "Enjoy!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Add Custom Elements to your Scene\n",
+    "This shows how to add a custom element, in this case a Cube, that will be placed in the center of your scene to mark the 0,0 location. A tracking-example with torque tube is used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "path = C:\\Users\\sayala\\Documents\\RadianceScenes\\demo\n",
+      "Getting weather file: USA_VA_Richmond.Intl.AP.724010_TMY.epw  ... OK!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'skies\\\\sky2_1axisTrack4020.rad'"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#First all the Variables:\n",
+    "testfolder = r'C:\\Users\\sayala\\Documents\\RadianceScenes\\demo'\n",
+    "\n",
+    "#Some variables again. Assuming bifacial_radiance was imported.\n",
+    "\n",
+    "timeindex = 4020 # Noon, June 17th. \n",
+    "simulationname = '1axisTrack'+str(timeindex)\n",
+    "\n",
+    "# MakeModule Parameters\n",
+    "module_type='my_little_pony_panel'\n",
+    "module_length = 1.996  # 2-up portrait Longi with 15cm additional gap\n",
+    "module_width = 0.991\n",
+    "orientation='portrait' \n",
+    "tilt = 10\n",
+    "\n",
+    "# Tracking Angle Calculation Parameters\n",
+    "hub_height = 0.5   \n",
+    "axis_azimuth = 180.0\n",
+    "roundTrackerAngleBool = True \n",
+    "angledelta = 5\n",
+    "limit_angle = 45\n",
+    "backtrack = True\n",
+    "    \n",
+    "# SceneDict Parameters\n",
+    "gcr = 0.33   # ground cover ratio,  = module_height / pitch\n",
+    "albedo = 0.28  #'concrete'     # ground albedo\n",
+    "\n",
+    "# Running the simulation\n",
+    "demo2 = RadianceObj(simulationname, path = testfolder)  # Create a RadianceObj 'object' named 'demo'\n",
+    "demo2.setGround(albedo) # input albedo number or material name like 'concrete'.  To see options, run this without any input.\n",
+    "epwfile = demo2.getEPW(37.5,-77.6) # pull TMY data for any global lat/lon\n",
+    "metdata = demo2.readEPW(epwfile) # read in the weather data\n",
+    "demo2.gendaylit(metdata, 4020)  # Noon, June 17th"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are going to create a \"Mycube.rad\" file in the objects folder, right after we make the Module. \n",
+    "This is a prism (so we use 'genbox'), that is black from the ground.rad list of materials ('black')\n",
+    "We are naming it 'cuteBox'\n",
+    "Its sides are going to be 0.5x0.5x0.5 m \n",
+    "and We are going to leave its bottom surface coincident with the plane z=0, but going to center on X and Y.\n",
+    "The command for this description is :\n",
+    ">'! genbox black PVmodule 0.5 0.5 0.5 | xform -t -0.25 -0.25 0'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('\\nModule Name:', 'my_little_pony_panel')\n",
+      "REWRITING pre-existing module file. \n",
+      "Module my_little_pony_panel successfully created\n",
+      "('\\nCustom Object Name', 'objects\\\\Mycube.rad')\n"
+     ]
+    }
+   ],
+   "source": [
+    "demo2.makeModule(name=module_type,x=module_width,y=module_length)   \n",
+    "name='Mycube'\n",
+    "text='! genbox black cuteBox 0.5 0.5 0.5 | xform -t -0.25 -0.25 0'\n",
+    "customObject = demo2.makeCustomObject(name,text)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are saving the filename and address into customObject so we can call it when making the Scene and add it to it.\n",
+    "\n",
+    "At this point, you can go to the objects folder and check that the object was created properly.\n",
+    "### objects\\\\Mycube.rad\n",
+    "\n",
+    "Let's create teh SCene now:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "For this timestamp, panels are facing West\n",
+      "Tracker theta has been calculated to 4.722 and rounded to nearest tracking angle 5.0\n",
+      "Module clearance height has been calculated to 0.413, for this tracker theta.\n"
+     ]
+    }
+   ],
+   "source": [
+    "tracker_theta, tracker_height, azimuth_ang = demo2._getTrackingGeometryTimeIndex(metdata, timeindex=timeindex, angledelta = angledelta, roundTrackerAngleBool = roundTrackerAngleBool, axis_azimuth = axis_azimuth, limit_angle = limit_angle, backtrack = backtrack, gcr = gcr, hubheight = hub_height, module_height = module_length )\n",
+    "sceneDict = {'tilt':tracker_theta,'pitch': module_length / gcr,'height':tracker_height,'orientation':orientation,'azimuth':azimuth_ang, 'module_type':module_type}  \n",
+    "scene = demo2.makeScene(module_type, sceneDict) #makeScene creates a .rad file with 20 modules per row, 7 rows."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's add the customObject to the Scene. We are not going to translate it or anything because we want it at the center, but you can pass translation, rotation, and any other XFORM command from Radiance.\n",
+    "\n",
+    "I am passing a rotation 0 because xform has to have something (I think) otherwise it gets confused."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 1axisTrack4020.oct\n"
+     ]
+    }
+   ],
+   "source": [
+    "demo2.appendtoScene(scene.radfile, customObject, '!xform -rz 0')\n",
+    "\n",
+    "octfile = demo2.makeOct(demo2.getfilelist())  # makeOct combines all of the ground, sky and object files into a .oct file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point you should be able to go into a command window (cmd.exe) and check the geometry. Example:\n",
+    "    \n",
+    "   #### rvu -vf views\\front.vp -e .01 Torque_tube_hex_test.oct\n",
+    "   \n",
+    "And then proceed happily with your analysis. If any of the sensors hits the Box object we just created, the list of materials should say something with \"cuteBox\" on it. (That's why I set the clearance so low for this example, so the module and the cuteBox intercept)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Linescan in process: 1axisTrack4020_Front\n",
+      "Linescan in process: 1axisTrack4020_Back\n",
+      "Saved: results\\irr_1axisTrack4020.csv\n",
+      "Annual bifacial ratio: 0.000 - 0.045\n"
+     ]
+    }
+   ],
+   "source": [
+    "analysis = AnalysisObj(octfile, demo2.basename)  # return an analysis object including the scan dimensions for back irradiance\n",
+    "frontDict, backDict = analysis.analysis(octfile, demo2.basename, scene.frontscan, scene.backscan)  # compare the back vs front irradiance  \n",
+    "print('Annual bifacial ratio: %0.3f - %0.3f' %(min(analysis.backRatio), np.mean(analysis.backRatio)) )"
    ]
   },
   {


### PR DESCRIPTION
Very simple change  to the New Functionality Journals and 2 new functions to be able to further customize for our projects the code. 

makeCustomObject creates a textfile.rad with whatever Radiance lingo text you place in it. 

appendtoScene appends whatever textfile.rad you want to the scene file. Useful for when we are doing more than 1 tracker or module styles in the same Scene. (I am currently planning to use it to test having a high-albedocloth under only certain parts of the tracker, not the whole ground, and check the sensitivity to that).

