### PR TITLE
originx and y fix ~ translation at the end not at the beginning.

### DIFF
--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -2314,7 +2314,7 @@ class SceneObj:
         ''' INITIALIZE VARIABLES '''
         text = '!xform '
 
-        text += '-rx %s -t %s %s %s ' %(tilt, originx, originy, hubheight)
+        text += '-rx %s -t %s %s %s ' %(tilt, 0, 0, hubheight)
         
         # create nMods-element array along x, nRows along y. 1cm module gap.
         text += '-a %s -t %s 0 0 -a %s -t 0 %s 0 ' %(nMods, self.scenex, nRows, pitch)
@@ -2323,9 +2323,9 @@ class SceneObj:
         # Modifying so center row is centered in the array. (i.e. 3 rows, row 2. 4 rows, row 2 too)
         # Since the array is already centered on row 1, module 1, we need to increment by Nrows/2-1 and Nmods/2-1
 
-        text += '-i 1 -t %s %s 0 -rz %s '%(-self.scenex*(round(nMods/1.999)*1.0-1),
+        text += '-i 1 -t %s %s 0 -rz %s -t %s %s 0 '%(-self.scenex*(round(nMods/1.999)*1.0-1),
                                             -pitch*(round(nRows / 1.999)*1.0-1),
-                                            180-azimuth)
+                                            180-azimuth, originx, originy)
         
         #axis tilt only working for N-S trackers
         if axis_tilt != 0 and azimuth == 90:  
@@ -2338,7 +2338,7 @@ class SceneObj:
             text += '-rx %s -t 0 0 %s ' %(axis_tilt, \
                 self.scenex*(round(nMods/1.99)*1.0-1)*np.sin(axis_tilt * np.pi/180) )
 
-        filename = '%s_%0.5s_%0.5s_%0.5s_%sx%s.rad'%(radname,height,pitch,tilt, nMods, nRows)
+        filename = '%s_%0.5s_%0.5s_%0.5s_%sx%s_origin%s,%s.rad'%(radname,height,pitch,tilt, nMods, nRows, originx, originy)
         if hpc:
             text += os.path.join(os.getcwd(), self.modulefile) 
             radfile = os.path.join(os.getcwd(), 'objects', filename) 
@@ -3084,8 +3084,8 @@ class AnalysisObj:
         if debug is True:
             print( "Sampling: modWanted %i, rowWanted %i out of %i modules, %i rows" % (modWanted, rowWanted, nMods, nRows))
 
-        x0 = originx + (modWanted-1)*scenex - (scenex*(round(nMods/1.99)*1.0-1))
-        y0 = originy + (rowWanted-1)*pitch - (pitch*(round(nRows / 1.99)*1.0-1))
+        x0 = (modWanted-1)*scenex - (scenex*(round(nMods/1.99)*1.0-1))
+        y0 = (rowWanted-1)*pitch - (pitch*(round(nRows / 1.99)*1.0-1))
 
         x1 = x0 * np.cos ((180-azimuth)*dtor) - y0 * np.sin((180-azimuth)*dtor)
         y1 = x0 * np.sin ((180-azimuth)*dtor) + y0 * np.cos((180-azimuth)*dtor)
@@ -3108,8 +3108,8 @@ class AnalysisObj:
         z3 = offset * np.cos(tilt*dtor)
 
 
-        xstart = x1 + x2 + x3
-        ystart = y1 + y2 + y3
+        xstart = x1 + x2 + x3 + originx
+        ystart = y1 + y2 + y3 + originy
         zstart = height + z1 + z2 + z3
 
         xinc = -(sceney/(sensorsy + 1.0)) * np.cos((tilt)*dtor) * np.sin((azimuth)*dtor)

--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -1628,7 +1628,10 @@ class RadianceObj:
 
         # py2 and 3 compatible: binary write, encode text first
         text2 = '\n' + text + ' ' + customObject
-        print (text2)
+        
+        debug = False
+        if debug:
+            print (text2)
 
         with open(radfile, 'a+') as f:
             f.write(text2)

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -175,7 +175,7 @@ def test_SceneObj_makeSceneNxR_lowtilt():
                               'xstart': 0,  'ystart': -0.374226946144639, 'zinc': 0.016496576878358378,
                               'zstart': 0.18649657687835838}) # zstart was 0.01 and zinc was 0 in v0.2.2
     #assert scene.text == '!xform -rz -90 -t -0.795 0.475 0 -rx 10 -t 0 0 0.2 -a 20 -t 1.6 0 0 -a 7 -t 0 1.5 0 -i 1 -t -15.9 -4.5 0 -rz 0 objects\\simple_panel.rad'
-    assert scene.text[0:107] == '!xform -rx 10 -t 0 0 0.2824828843917919 -a 20 -t 1.6 0 0 -a 7 -t 0 1.5 0 -i 1 -t -14.4 -4.5 0 -rz 0 objects' #linux has different directory structure and will error here.
+    assert scene.text[0:116] == '!xform -rx 10 -t 0 0 0.2824828843917919 -a 20 -t 1.6 0 0 -a 7 -t 0 1.5 0 -i 1 -t -14.4 -4.5 0 -rz 0 -t 0 0 0 objects' #linux has different directory structure and will error here.
 
 def test_SceneObj_makeSceneNxR_hightilt():
     # test makeSceneNxR(tilt, height, pitch, orientation = None, azimuth = 180, nMods = 20, nRows = 7, radname = None)
@@ -215,7 +215,7 @@ def test_SceneObj_makeSceneNxR_hightilt():
     assert backscan == pytest.approx({'Nx': 1, 'Ny': 9, 'Nz': 1, 'xinc': -0.040142620018581696, 'xstart': 0.16057048007432673, 
                             'yinc': -0.0007006920388131139, 'ystart': 0.002802768155252455, 'zinc': 0.08609923976848174, 'zstart': 0.2560992397684817})
     #assert scene.text == '!xform -rz -90 -t -0.795 0.475 0 -rx 65 -t 0 0 0.2 -a 20 -t 1.6 0 0 -a 7 -t 0 1.5 0 -i 1 -t -15.9 -4.5 0 -rz 91 objects\\simple_panel.rad'
-    assert scene.text[0:108] == '!xform -rx 65 -t 0 0 0.6304961988424087 -a 20 -t 1.6 0 0 -a 7 -t 0 1.5 0 -i 1 -t -14.4 -4.5 0 -rz 91 objects'
+    assert scene.text[0:117] == '!xform -rx 65 -t 0 0 0.6304961988424087 -a 20 -t 1.6 0 0 -a 7 -t 0 1.5 0 -i 1 -t -14.4 -4.5 0 -rz 91 -t 0 0 0 objects'
     
 
  


### PR DESCRIPTION
originx and y fix ~ translation at the end not at the beginning.

Also, file name of .rad now includes origin coordinates (otherwise modules get overwritten when doing multiple scene objects on the same row).