### PR TITLE
Fix broken paths to images in jupyter notebooks

### DIFF
--- a/docs/tutorials/v3 - 2-UP with Torque Tube, Fixed Tilt Example, with CLEAN Routine.ipynb
+++ b/docs/tutorials/v3 - 2-UP with Torque Tube, Fixed Tilt Example, with CLEAN Routine.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "It will look something like this (without the optional steps 3 and 5):\n",
     "\n",
-    "![What we are trying to re-create](images_wiki/Journal_example_torquetube.PNG)"
+    "![What we are trying to re-create](../images_wiki/Journal_example_torquetube.PNG)"
    ]
   },
   {
@@ -1435,7 +1435,7 @@
     "   \n",
     "If you ran the getTrackerAngle detour and appended the marker, it should look like this:\n",
     "\n",
-    "![Marker position at 0,0](images_wiki\\Journal_example_marker_origin.PNG)\n",
+    "![Marker position at 0,0](../images_wiki/Journal_example_marker_origin.PNG)\n",
     "\n",
     "If you do an analysis and any of the sensors hits the Box object we just created, the list of materials in the result.csv file should say something with \"CenterMarker\" on it. \n",
     "\n",

--- a/docs/tutorials/v3 - Bifacial Carports and Canopies.ipynb
+++ b/docs/tutorials/v3 - Bifacial Carports and Canopies.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "4) Adding a flat surface to simulate a car with a specific reflectivity.\n",
     "\n",
-    "![title](images_wiki/Carport.png)\n"
+    "![title](../images_wiki/Carport.png)\n"
    ]
   },
   {
@@ -212,7 +212,7 @@
     "\n",
     "-pe sets the exposure levels, and -vp sets the view point so the carport is centered (at least on my screen. you can play with the values). It should look like this:\n",
     "\n",
-    "![title](images_wiki/Carport.png)\n",
+    "![title](../images_wiki/Carport.png)\n",
     "\n",
     "The post should be coindient with the corners of the array on the high-end of the carport, and on the low end of the carport they should be between the lowest module and the next one. Cute! \n",
     "\n",
@@ -253,7 +253,7 @@
    "metadata": {},
    "source": [
     "This is the module analysis and an image of the results file\n",
-    "![This is the module analysed.](images_wiki/Carport_analysis.png)\n",
+    "![This is the module analysed.](../images_wiki/Carport_analysis.png)\n",
     "\n",
     "You can repeat the analysis for any other module in the row."
    ]
@@ -383,7 +383,7 @@
     "Viewing with:\n",
     "## rvu -vf views\\front.vp -e .01 -pe 0.019 -vp 1.5 -14 15 HotelCarport.oct\n",
     "\n",
-    "![Behold the Honda-fit sized cube](images_wiki/Carport_with_car.png)"
+    "![Behold the Honda-fit sized cube](../images_wiki/Carport_with_car.png)"
    ]
   }
  ],

--- a/docs/tutorials/v3 - Multiple SceneObjects Example.ipynb
+++ b/docs/tutorials/v3 - Multiple SceneObjects Example.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "A scene Object is defined as an array of modules, with whatever parameters you want to give it. In this case, we are modeling one array of 2 rows of 5 modules in landscape, and one array of 1 row of 5 modules in 2-UP, portrait configuration, as the image below:\n",
     "\n",
-    "![multiple Scene Objects Example](images_wiki\\Journal_example_multiple_objects.PNG)\n"
+    "![multiple Scene Objects Example](../images_wiki/Journal_example_multiple_objects.PNG)\n"
    ]
   },
   {


### PR DESCRIPTION
Some of the markdown in the jupyter notebook tutorials had broken paths to images.