### PR TITLE
Migrate from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,33 @@
+name: Deploy Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Deploy to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: |
+          dist/*

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,72 @@
+name: test
+
+on: [pull_request, push]
+
+jobs:
+  pytest:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # don't cancel other matrix jobs when one fails
+      matrix:
+        python-version: ["3.7"]
+        # Test two environments:
+        # 1) dependencies with pinned versions from requirements.txt
+        # 2) 'pip install --upgrade --upgrade-strategy=eager .' to install upgraded
+        #    dependencies from PyPi using version ranges defined within setup.py
+        env: [
+          '-r requirements.txt .[all]',
+          '--upgrade --upgrade-strategy=eager .[all]'
+        ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Radiance v5.2
+      run: |
+        wget https://github.com/NREL/Radiance/releases/download/5.2/radiance-5.2.dd0f8e38a7-Linux.tar.gz -O /tmp/radiance.tar.gz
+        tar -xvf /tmp/radiance.tar.gz
+
+    - name: Copy gencumulativesky into radiance /bin
+      run: |
+        cp $PWD/bifacial_radiance/data/gencumulativesky $PWD/radiance-5.2.dd0f8e38a7-Linux/usr/local/radiance/bin/
+
+    - name: Install SMARTS 2.9.5
+      run: |
+        wget https://www.nrel.gov/grid/solar-resource/assets/data/smarts-295-linux-tar.gz -O /tmp/smarts.tar.gz
+        tar -xvf /tmp/smarts.tar.gz
+        unlink $PWD/SMARTS_295_Linux/smarts295bat
+        sed -i 's/batch=.FALSE./batch=.TRUE./g' $PWD/SMARTS_295_Linux/Source_code/smarts295.f
+        sudo apt-get install gfortran
+        gfortran -o $PWD/SMARTS_295_Linux/smarts295bat $PWD/SMARTS_295_Linux/Source_code/smarts295.f
+        ls -l $PWD/SMARTS_295_Linux/
+
+    - name: Install ${{ matrix.env }}
+      run: |
+        pip install ${{ matrix.env }}
+        pip install coveralls wheel
+
+    - name: Set environment variables
+      run: |
+        # https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#adding-a-system-path
+        echo "/home/runner/work/bifacial_radiance/bifacial_radiance/radiance-5.2.dd0f8e38a7-Linux/usr/local/radiance/bin" >> $GITHUB_PATH
+        echo "/home/runner/work/bifacial_radiance/bifacial_radiance/SMARTS_295_Linux" >> $GITHUB_PATH
+
+    - name: Test with pytest ${{ matrix.env }}
+      uses: GabrielBB/xvfb-action@v1  # GUI testing requires xvfb
+      with:
+        run: |
+          pytest --cov=bifacial_radiance
+      env:  # environment variables available to this step
+        RAYPATH: .:/home/runner/work/bifacial_radiance/bifacial_radiance/radiance-5.2.dd0f8e38a7-Linux/usr/local/radiance/lib
+        SMARTSPATH: /home/runner/work/bifacial_radiance/bifacial_radiance/SMARTS_295_Linux
+
+    - name: Coveralls
+      run: |
+        coveralls
+


### PR DESCRIPTION
This PR adds GitHub Actions workflows for running the test suite and deploying releases to PyPI.  It was made much easier by having the current Travis config as a reference!

There is one test failure (`test_readWeatherFile_subhourly`) that I think is not a problem with the CI configuration but instead some other issue.  Seems like #340 ran into the same thing, so I figured I'd leave it alone here.  

Also, the eager-upgrade variant is failing the `test_SingleModule_gencumsky_modelchain` test -- is that a problem here?

To-do:
- [ ] remove `.travis.yml` and disable travis
- [ ] add PyPI deploy secrets to repo settings