### PR TITLE
Fix docker worfklow in GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,10 @@ on:
 
   # Run tests for any PRs.
   pull_request:
+  
+  # Allow running this action on demand
+  workflow_dispatch:
+  
 
 # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,21 +2,18 @@ name: Push Docker image to GitHub Pack Registry
 
 on:
   push:
+  
     # Publish `main` as Docker `latest` image.
     branches:
-      - development
+    - development
 
     # Publish `v1.2.3` tags as releases.
-    tags:
-
+#     tags:
 
   # Run tests for any PRs.
   pull_request:
 
-env:
-  # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
-  IMAGE_NAME: "$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
-  DOCKERFILE_PATH: "./docker/Dockerfile"
+# https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
 
 jobs:
 
@@ -29,54 +26,31 @@ jobs:
       - name: Print triggering event info
         run: |
           echo "${{ github.actor }} triggered run #${{ github.run_number }} with event type ${{ github.event_name }}"
-      # - name: Build image
-      #   run: docker build . --file "$DOCKERFILE_PATH" --tag $IMAGE_NAME
-        
-      - uses: whoan/docker-build-with-cache-action@v5
-        with:
-          image_name: "$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
-          image_tag: latest
-          context: '.'
-          dockerfile: "./docker/Dockerfile"
-          push_image_and_stages: false
 
-      - name: Log into registries
-        run: |
-          <<<"${{ secrets.GITHUB_TOKEN }}"         docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-          <<<"${{ secrets.DOCKERHUB_NREL_TOKEN }}" docker login -u ${{ secrets.DOCKERHUB_NREL_USER }} --password-stdin
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
         
-      - name: Push image to repositories
-        run: |
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_NREL_USER }}
+          password: ${{ secrets.DOCKERHUB_NREL_TOKEN }}
+      
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           
-          REF=$VERSION
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "development" ] && VERSION=latest
-          
-          GITHUB_IMAGE_URL=docker.pkg.github.com/$IMAGE_NAME/$REF
-          DOCKER_IMAGE_URL=docker.io/nrel/bifacial_radiance
-          # Change all uppercase to lowercase
-          GITHUB_IMAGE_URL="${GITHUB_IMAGE_URL,,}"
-          DOCKER_IMAGE_URL="${DOCKER_IMAGE_URL,,}"
-          echo VERSION=$VERSION
-          
-          # Push image to GitHub Packages.
-          (
-            echo GITHUB_IMAGE_URL=$GITHUB_IMAGE_URL
-            echo IMAGE_NAME=$IMAGE_NAME	
-            docker tag $IMAGE_NAME $GITHUB_IMAGE_URL:$VERSION
-            docker push $GITHUB_IMAGE_URL:$VERSION
-          ) &
-          
-          # Push image to Docker Hub.
-          (
-            echo DOCKER_IMAGE_URL=${DOCKER_IMAGE_URL,,}
-            echo IMAGE_NAME=$IMAGE_NAME	 
-            docker tag $IMAGE_NAME ${DOCKER_IMAGE_URL,,}:$VERSION
-            docker push ${DOCKER_IMAGE_URL,,}:$VERSION
-          ) &
-          
-          wait
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            nrel/bifacial_radiance:latest
+            ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
Use official docker GitHub Actions.
This may require some configuration in ghcr.io to make it work since that's what I had to do in my fork. If this throws a 403 error in the build then that's the indicator.