### PR TITLE
405 multiple analysis objs

### DIFF
--- a/bifacial_radiance/load.py
+++ b/bifacial_radiance/load.py
@@ -290,7 +290,7 @@ def loadTrackerDict(trackerdict, fileprefix=None):
     #end loadTrackerDict subroutine.  set demo.Wm2Front = totaldict.Wm2Front. demo.Wm2Back = totaldict.Wm2Back
 
 
-def _exportTrackerDict(trackerdict, savefile, reindex):
+def _exportTrackerDict(trackerdict, savefile, reindex=False):
     """
     Save a TrackerDict output as a ``.csv`` file.
     
@@ -303,7 +303,8 @@ def _exportTrackerDict(trackerdict, savefile, reindex):
         reindex : bool
             Boolean indicating if trackerdict should be resampled to include
             all 8760 hours in the year (even those when the sun is not up and 
-            irradiance results is empty).
+            irradiance results is empty). NOTE: this is incompatible with multiple
+            row / modules per trackerdict entry.
     
     """
     from pandas import DataFrame as df
@@ -316,17 +317,29 @@ def _exportTrackerDict(trackerdict, savefile, reindex):
                    'wind_speed', 'theta','surf_tilt','surf_azm',
                    'clearance_height', 
                    # Not including the whole distribution because these are not clean..
-                   'Wm2Back','Wm2Front',
                    'POA_eff', 'Gfront_mean',
                    'Grear_mean', 
-                   'Pout_module', 'Mismatch', 'Pout_module_reduced', ])
-
+                   'Pout_module', 'Mismatch', 'Pout_module_reduced', ])   
     d['measdatetime'] = d.index
+
+       
+    # add trackerdict Results (not all simulations will have results)
+    try:
+        results = pd.concat([df(data=value['Results'],index=[key]*len(value['Results'])) for (key,value) in trackerdict.items()])
+        results = results[['rowWanted','modWanted','Wm2Front','Wm2Back']]
+        d = results.join(d)
+    except KeyError:
+        pass
+    
 
     if reindex is True: # change to proper timestamp and interpolate to get 8760 output
         d['measdatetime'] = d.index
         d=d.set_index(pd.to_datetime(d['measdatetime'], format='%Y-%m-%d_%H%M'))
-        d=d.resample('H').asfreq()
+        try:
+            d=d.resample('H').asfreq()
+        except ValueError:
+            print('Warning: Unable to reindex - possibly duplicate entries in trackerdict')
+
   
     d.to_csv(savefile)    
 

--- a/bifacial_radiance/load.py
+++ b/bifacial_radiance/load.py
@@ -738,12 +738,12 @@ def readconfigurationinputfile(inifile=None):
             print("Load Warning: improper or no analysisParamsDict['sensorsy']"
                   " passed, setting to default value: %s" % analysisParamsDict['sensorsy'] )    
         try: 
-            analysisParamsDict['modWanted']=int(analysisParamsDict['modWanted']) 
+            analysisParamsDict['modWanted']=ast.literal_eval(analysisParamsDict['modWanted']) 
         except:
             analysisParamsDict['modWanted'] = None #Default
             print("analysisParamsDict['modWanted'] set to middle module by default" )    
         try: 
-            analysisParamsDict['rowWanted']=int(analysisParamsDict['rowWanted']) 
+            analysisParamsDict['rowWanted']=ast.literal_eval(analysisParamsDict['rowWanted']) 
         except:
             analysisParamsDict['rowWanted'] = None #Default
             print("analysisParamsDict['rowWanted'] set to middle row by default" )    

--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -2587,22 +2587,26 @@ class RadianceObj:
                 except AttributeError as  e:  # no key Wm2Front.
                     warnings.warn('Index: {}. Trackerdict key not found: {}. Skipping'.format(index,e), Warning)
                     return
-    
-                if np.sum(frontWm2) == 0:  # define frontWm2 the first time through
-                    frontWm2 =  np.array(analysis.Wm2Front)
-                    backWm2 =  np.array(analysis.Wm2Back)
-                else:
-                    frontWm2 +=  np.array(analysis.Wm2Front)
-                    backWm2 +=  np.array(analysis.Wm2Back)
-                print('Index: {}. Wm2Front: {}. Wm2Back: {}'.format(index,
-                      np.mean(analysis.Wm2Front), np.mean(analysis.Wm2Back)))
-                
                 trackerdict[index]['Results'].append(Results)
+                
+                print('Index: {}. Wm2Front: {}. Wm2Back: {}'.format(index,
+                  np.mean(analysis.Wm2Front), np.mean(analysis.Wm2Back)))
+                
+            # TODO: what to do with these cumulative values when you have multiple modules?
+            # The way it is here, only the last module/row pair is saved...
+            if np.sum(frontWm2) == 0:  # define frontWm2 the first time through
+                frontWm2 =  np.array(analysis.Wm2Front)
+                backWm2 =  np.array(analysis.Wm2Back)
+            else:
+                frontWm2 +=  np.array(analysis.Wm2Front)
+                backWm2 +=  np.array(analysis.Wm2Back)
+
+                
             if np.sum(self.Wm2Front) == 0:
-                self.Wm2Front = frontWm2   # these are accumulated over all indices AND modules AND rows passed in.
+                self.Wm2Front = frontWm2   # these are accumulated over all indices just for the last module / row passed in.
                 self.Wm2Back = backWm2
             else:
-                self.Wm2Front += frontWm2   # these are accumulated over all indices AND modules AND rows passed in.
+                self.Wm2Front += frontWm2   # these are accumulated over all indices just for the last module / row passed in.
                 self.Wm2Back += backWm2
             self.backRatio = np.mean(backWm2)/np.mean(frontWm2+.001)
 
@@ -2610,8 +2614,8 @@ class RadianceObj:
         if singleindex is None:
         
             print ("Saving a cumulative-results file in the main simulation folder." +
-                   "This adds up by sensor location the irradiance over all rows, modules and hours " +
-                   "or configurations considered." +
+                   "This adds up by sensor location the irradiance over all hours " +
+                   "or configurations considered. (last module/row pair only) " +
                    "\nWarning: This file saving routine does not clean results, so "+
                    "if your setup has ygaps, or 2+modules or torque tubes, doing "+
                    "a deeper cleaning and working with the individual results "+

--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -2665,30 +2665,35 @@ class RadianceObj:
         #    print("Add HERE gencusky1axis results for each tracekr angle")
 
         #else:
-        # TODO: loop over module and row values in 'Results'
+        # loop over module and row values in 'Results'
         temp_air = []
         wind_speed = []
         Wm2Front = []
         Wm2Back = []
         rearMat = []
         frontMat = []
+        rowWanted = []
+        modWanted = []
         for key in keys:
-            Wm2Front.append(trackerdict[key]['Results'][0]['AnalysisObj'].Wm2Front)
-            Wm2Back.append(trackerdict[key]['Results'][0]['AnalysisObj'].Wm2Back)
-            frontMat.append(trackerdict[key]['Results'][0]['AnalysisObj'].mattype)
-            rearMat.append(trackerdict[key]['Results'][0]['AnalysisObj'].rearMat)
-            temp_air.append(trackerdict[key]['temp_air'])
-            wind_speed.append(trackerdict[key]['wind_speed'])
-     
+            for row_mod in trackerdict[key]['Results']: # loop over multiple row & module in trackerDict['Results']
+                temp_air.append(trackerdict[key]['temp_air'])
+                wind_speed.append(trackerdict[key]['wind_speed'])
+                Wm2Front.append(row_mod['AnalysisObj'].Wm2Front)
+                Wm2Back.append(row_mod['AnalysisObj'].Wm2Back)
+                frontMat.append(row_mod['AnalysisObj'].mattype)
+                rearMat.append(row_mod['AnalysisObj'].rearMat)
+                rowWanted.append(row_mod['AnalysisObj'].rowWanted)
+                modWanted.append(row_mod['AnalysisObj'].modWanted)     
         # Update tracker dict now!
 #       trackerdict[key]['effective_irradiance'] = eff_irrad
             
         data= pd.DataFrame(zip(keys, Wm2Front, Wm2Back, frontMat, rearMat,  
-                                             wind_speed, temp_air), 
+                                             wind_speed, temp_air, rowWanted, modWanted), 
                                          columns=('timestamp', 'Wm2Front', 
                                                   'Wm2Back', 'mattype',
                                                   'rearMat',
-                                                  'wind_speed', 'temp_air'))
+                                                  'wind_speed', 'temp_air',
+                                                  'rowWanted','modWanted'))
         
         
         results = performance.arrayResults(CECMod=CECMod, results=data,

--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -348,6 +348,7 @@ class RadianceObj:
         self.nMods = None        # number of modules per row
         self.nRows = None        # number of rows per scene
         self.hpc = hpc           # HPC simulation is being run. Some read/write functions are modified
+        self.CompiledResults = None
         
         now = datetime.datetime.now()
         self.nowstr = str(now.date())+'_'+str(now.hour)+str(now.minute)+str(now.second)
@@ -2649,7 +2650,7 @@ class RadianceObj:
             bifacialityfactor = trackerdict[keys[0]]['scene'].module.bifi
             print("Bifaciality factor of module stored is ", bifacialityfactor)
 
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1``34
         # TODO IMPORTANT: ADD CUMULATIVE CHEck AND WHOLE OTHER PROCESSING OPTION
         # TO EMULATE WHAT HAPPENED BEFORE WITH GENCUMSKY1AXIS when trackerdict = cumulative = True
         # if cumulative:

--- a/bifacial_radiance/modelchain.py
+++ b/bifacial_radiance/modelchain.py
@@ -191,7 +191,7 @@ def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=N
                # What was before:         
                # analysis = trackerdict[time]['AnalysisObj']
 
-        analysis = demo.trackerdict[list(demo.trackerdict.keys())[-1]]['AnalysisObj']
+        analysis = demo.trackerdict[list(demo.trackerdict.keys())[-1]]['Results'][0]['AnalysisObj']
         
         if simulationParamsDict['cumulativeSky']:
             print("Finished! ")

--- a/bifacial_radiance/modelchain.py
+++ b/bifacial_radiance/modelchain.py
@@ -204,12 +204,7 @@ def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=N
             if CECModParamsDict:
                 CECMod = pd.DataFrame(CECModParamsDict, index=[0])
             else:
-                print("No CECModule data passed; using default for Prism Solar BHC72-400")
-                #url = 'https://raw.githubusercontent.com/NREL/SAM/patch/deploy/libraries/CEC%20Modules.csv'
-                url = os.path.join(bifacial_radiance.main.DATA_PATH,'CEC Modules.csv')
-                db = pd.read_csv(url, index_col=0) # Reading this might take 1 min or so, the database is big.
-                modfilter2 = db.index.str.startswith('Pr') & db.index.str.endswith('BHC72-400')
-                CECMod = db[modfilter2]
+                CECMod = None
             demo.calculateResults(CECMod = CECMod)
             demo.exportTrackerDict(savefile=os.path.join('results','Final_Results.csv'),reindex=False)
 

--- a/docs/sphinx/source/manualapi.rst
+++ b/docs/sphinx/source/manualapi.rst
@@ -112,6 +112,7 @@ Methods for irradiance calculations
    AnalysisObj.moduleAnalysis
    AnalysisObj.analysis
    RadianceObj.analysis1axis
+   RadianceObj.compileResults
 
 Mismatch
 --------

--- a/docs/sphinx/source/whatsnew/pending.rst
+++ b/docs/sphinx/source/whatsnew/pending.rst
@@ -1,0 +1,33 @@
+.. _whatsnew_0420:
+
+v0.4.2 (XX / XX / 2022)
+------------------------
+Release of new version including ...
+
+
+API Changes
+~~~~~~~~~~~~
+*A new function must now be called to compile results and report out final irradiance and performance data: :py:class:`~bifacial_radiance.RadianceObj.compileResults`.
+*Multiple modules and rows can now be selected in a single analysis scan. ``modWanted`` and ``rowWanted`` inputs in :py:class:`~bifacial_radiance.RadianceObj.analysis1axis` can now be a list, to select multiple rows and modules for scans. (:issue:`405`)(:pull:`408`)
+*To support multiple modules and row scans for 1axis simulations, outputs like Wm2Front are now stored in ``trackerdict``.``Results``  (:issue:`405`)(:pull:`408`)
+
+
+Enhancements
+~~~~~~~~~~~~
+
+
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~~
+
+
+
+Contributors
+~~~~~~~~~~~~
+* Silvana Ayala (:ghuser:`shirubana`)
+* Chris Deline (:ghuser:`cdeline`)

--- a/docs/tutorials/modelchain test.html
+++ b/docs/tutorials/modelchain test.html
@@ -14173,7 +14173,7 @@ a.anchor-link {
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
 <pre>
 New bifacial_radiance simulation starting. 
-Version:  0.4.1+15.gb7a948e.dirty
+Version:  0.4.1+16.g0c78455.dirty
 path = C:\Users\sayala\Documents\GitHub\bifacial_radiance\bifacial_radiance\TEMP\Modelchain
 Loading times to restrict weather data to
 analysisParamsDict[&#39;modWanted&#39;] set to middle module by default
@@ -14207,61 +14207,45 @@ Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Front
 Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Back
 Saved: results\irr_1axis_2021-06-17_1300_Row2_Module5_Front.csv
 Saved: results\irr_1axis_2021-06-17_1300_Row2_Module5_Back.csv
-Index: 2021-06-17_1300. Wm2Front: 898.4182666666667. Wm2Back: 188.6046951851852
+Index: 2021-06-17_1300. Wm2Front: 897.6890375. Wm2Back: 188.0002166666667
 Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Front
 Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Back
 Saved: results\irr_1axis_2021-06-17_1400_Row2_Module5_Front.csv
 Saved: results\irr_1axis_2021-06-17_1400_Row2_Module5_Back.csv
-Index: 2021-06-17_1400. Wm2Front: 646.4604708333333. Wm2Back: 153.67998259259258
+Index: 2021-06-17_1400. Wm2Front: 646.1976916666667. Wm2Back: 152.18251999999998
 
 --&gt; Calculating Performance values
 Bifaciality factor of module stored is  0.8
+Exporting TrackerDict
 </pre>
 </div>
 </div>
 
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>
-<span class="ansi-red-intense-fg ansi-bold">---------------------------------------------------------------------------</span>
-<span class="ansi-red-intense-fg ansi-bold">AttributeError</span>                            Traceback (most recent call last)
-<span class="ansi-green-intense-fg ansi-bold">~\AppData\Local\Temp\1/ipykernel_10944/1998972661.py</span> in <span class="ansi-cyan-fg">&lt;module&gt;</span>
-<span class="ansi-green-intense-fg ansi-bold">----&gt; 1</span><span class="ansi-yellow-intense-fg ansi-bold"> </span>demo2<span class="ansi-yellow-intense-fg ansi-bold">,</span> analysis <span class="ansi-yellow-intense-fg ansi-bold">=</span> bifacial_radiance<span class="ansi-yellow-intense-fg ansi-bold">.</span>modelchain<span class="ansi-yellow-intense-fg ansi-bold">.</span>runModelChain<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-yellow-intense-fg ansi-bold">*</span>Params <span class="ansi-yellow-intense-fg ansi-bold">)</span>
-
-<span class="ansi-green-intense-fg ansi-bold">c:\users\sayala\documents\github\bifacial_radiance\bifacial_radiance\modelchain.py</span> in <span class="ansi-cyan-fg">runModelChain</span><span class="ansi-blue-intense-fg ansi-bold">(simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellModuleDict, CECModParamsDict)</span>
-<span class="ansi-green-fg">    211</span>                 modfilter2 <span class="ansi-yellow-intense-fg ansi-bold">=</span> db<span class="ansi-yellow-intense-fg ansi-bold">.</span>index<span class="ansi-yellow-intense-fg ansi-bold">.</span>str<span class="ansi-yellow-intense-fg ansi-bold">.</span>startswith<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#39;Pr&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">)</span> <span class="ansi-yellow-intense-fg ansi-bold">&amp;</span> db<span class="ansi-yellow-intense-fg ansi-bold">.</span>index<span class="ansi-yellow-intense-fg ansi-bold">.</span>str<span class="ansi-yellow-intense-fg ansi-bold">.</span>endswith<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#39;BHC72-400&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">)</span>
-<span class="ansi-green-fg">    212</span>                 CECMod <span class="ansi-yellow-intense-fg ansi-bold">=</span> db<span class="ansi-yellow-intense-fg ansi-bold">[</span>modfilter2<span class="ansi-yellow-intense-fg ansi-bold">]</span>
-<span class="ansi-green-intense-fg ansi-bold">--&gt; 213</span><span class="ansi-yellow-intense-fg ansi-bold">             </span>demo<span class="ansi-yellow-intense-fg ansi-bold">.</span>calculateResults<span class="ansi-yellow-intense-fg ansi-bold">(</span>CECMod <span class="ansi-yellow-intense-fg ansi-bold">=</span> CECMod<span class="ansi-yellow-intense-fg ansi-bold">)</span>
-<span class="ansi-green-fg">    214</span>             demo<span class="ansi-yellow-intense-fg ansi-bold">.</span>exportTrackerDict<span class="ansi-yellow-intense-fg ansi-bold">(</span>savefile<span class="ansi-yellow-intense-fg ansi-bold">=</span>os<span class="ansi-yellow-intense-fg ansi-bold">.</span>path<span class="ansi-yellow-intense-fg ansi-bold">.</span>join<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#39;results&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">,</span><span class="ansi-blue-intense-fg ansi-bold">&#39;Final_Results.csv&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">)</span><span class="ansi-yellow-intense-fg ansi-bold">,</span>reindex<span class="ansi-yellow-intense-fg ansi-bold">=</span><span class="ansi-green-intense-fg ansi-bold">False</span><span class="ansi-yellow-intense-fg ansi-bold">)</span>
-<span class="ansi-green-fg">    215</span> 
-
-<span class="ansi-green-intense-fg ansi-bold">c:\users\sayala\documents\github\bifacial_radiance\bifacial_radiance\main.py</span> in <span class="ansi-cyan-fg">calculateResults</span><span class="ansi-blue-intense-fg ansi-bold">(self, CECMod, glassglass, bifacialityfactor, CECMod2)</span>
-<span class="ansi-green-fg">   2650</span>             print<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#34;Bifaciality factor of module stored is &#34;</span><span class="ansi-yellow-intense-fg ansi-bold">,</span> bifacialityfactor<span class="ansi-yellow-intense-fg ansi-bold">)</span>
-<span class="ansi-green-fg">   2651</span> 
-<span class="ansi-green-intense-fg ansi-bold">-&gt; 2652</span><span class="ansi-yellow-intense-fg ansi-bold">         </span><span class="ansi-green-intense-fg ansi-bold">if</span> self<span class="ansi-yellow-intense-fg ansi-bold">.</span>cumulative<span class="ansi-yellow-intense-fg ansi-bold">:</span>
-<span class="ansi-green-fg">   2653</span>             print<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#34;Add HERE gencusky1axis results for each tracekr angle&#34;</span><span class="ansi-yellow-intense-fg ansi-bold">)</span>
-<span class="ansi-green-fg">   2654</span> 
-
-<span class="ansi-red-intense-fg ansi-bold">AttributeError</span>: &#39;RadianceObj&#39; object has no attribute &#39;cumulative&#39;</pre>
-</div>
 </div>
 
 </div>
 
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">analysis</span> <span class="o">--</span> <span class="n">Wm2Back</span> <span class="n">adn</span> <span class="n">Wm2Front</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
 </div>
 
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[9]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[13]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="o">.</span><span class="vm">__dict__</span>
 </pre></div>
 
      </div>
@@ -14277,18 +14261,101 @@ Bifaciality factor of module stored is  0.8
 <div class="jp-OutputArea-child">
 
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[13]:</div>
 
 
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>
-<span class="ansi-red-intense-fg ansi-bold">---------------------------------------------------------------------------</span>
-<span class="ansi-red-intense-fg ansi-bold">NameError</span>                                 Traceback (most recent call last)
-<span class="ansi-green-intense-fg ansi-bold">~\AppData\Local\Temp\1/ipykernel_10944/1149153798.py</span> in <span class="ansi-cyan-fg">&lt;module&gt;</span>
-<span class="ansi-green-intense-fg ansi-bold">----&gt; 1</span><span class="ansi-yellow-intense-fg ansi-bold"> </span>demo2
 
-<span class="ansi-red-intense-fg ansi-bold">NameError</span>: name &#39;demo2&#39; is not defined</pre>
+
+<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
+<pre>{&#39;metdata&#39;: &lt;bifacial_radiance.main.MetObj at 0x190eee00f10&gt;,
+ &#39;data&#39;: {},
+ &#39;path&#39;: &#39;C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\bifacial_radiance\\TEMP\\Modelchain&#39;,
+ &#39;name&#39;: &#39;2021-06-17_1400&#39;,
+ &#39;materialfiles&#39;: [&#39;materials\\ground.rad&#39;],
+ &#39;skyfiles&#39;: [&#39;skies\\sky2_39.742_-105.179_2021-06-17_1400.rad&#39;],
+ &#39;radfiles&#39;: [],
+ &#39;octfile&#39;: &#39;1axis_2021-06-17_1400.oct&#39;,
+ &#39;Wm2Front&#39;: 0,
+ &#39;Wm2Back&#39;: 0,
+ &#39;backRatio&#39;: 0,
+ &#39;nMods&#39;: 10,
+ &#39;nRows&#39;: 3,
+ &#39;hpc&#39;: False,
+ &#39;nowstr&#39;: &#39;2022-03-11_1138&#39;,
+ &#39;basename&#39;: &#39;_test_high_azimuth_angle_modelchain&#39;,
+ &#39;gencumsky_metfile&#39;: &#39;EPWs\\metdata_temp.csv&#39;,
+ &#39;ground&#39;: &lt;bifacial_radiance.main.GroundObj at 0x190ec97ee50&gt;,
+ &#39;module&#39;: {&#39;x&#39;: 1.59, &#39;y&#39;: 0.95, &#39;z&#39;: 0.02, &#39;modulematerial&#39;: &#39;black&#39;, &#39;scenex&#39;: 1.59, &#39;sceney&#39;: 0.95, &#39;scenez&#39;: 0.0, &#39;numpanels&#39;: 1, &#39;bifi&#39;: 0.8, &#39;text&#39;: &#39;! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0&#39;, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;glass&#39;: False, &#39;offsetfromaxis&#39;: 0, &#39;xgap&#39;: 0.0, &#39;ygap&#39;: 0.0, &#39;zgap&#39;: 0.0},
+ &#39;trackerdict&#39;: {&#39;2021-06-17_1300&#39;: {&#39;surf_azm&#39;: 30.0,
+   &#39;surf_tilt&#39;: 10.0,
+   &#39;theta&#39;: 10.0,
+   &#39;ghi&#39;: 959,
+   &#39;dhi&#39;: 172,
+   &#39;temp_air&#39;: 28.9,
+   &#39;wind_speed&#39;: 6.2,
+   &#39;skyfile&#39;: &#39;skies\\sky2_39.742_-105.179_2021-06-17_1300.rad&#39;,
+   &#39;clearance_height&#39;: 0.2,
+   &#39;radfile&#39;: &#39;objects\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;,
+   &#39;scene&#39;: {&#39;module&#39;: {&#39;x&#39;: 1.59, &#39;y&#39;: 0.95, &#39;z&#39;: 0.02, &#39;modulematerial&#39;: &#39;black&#39;, &#39;scenex&#39;: 1.59, &#39;sceney&#39;: 0.95, &#39;scenez&#39;: 0.0, &#39;numpanels&#39;: 1, &#39;bifi&#39;: 0.8, &#39;text&#39;: &#39;! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0&#39;, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;glass&#39;: False, &#39;offsetfromaxis&#39;: 0, &#39;xgap&#39;: 0.0, &#39;ygap&#39;: 0.0, &#39;zgap&#39;: 0.0}, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;hpc&#39;: False, &#39;gcr&#39;: 0.6333333333333333, &#39;text&#39;: &#39;!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\test-module.rad&#39;, &#39;radfiles&#39;: &#39;objects\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;, &#39;sceneDict&#39;: {&#39;tilt&#39;: 10.0, &#39;pitch&#39;: 1.5, &#39;clearance_height&#39;: 0.2, &#39;azimuth&#39;: 30.0, &#39;nMods&#39;: 10, &#39;nRows&#39;: 3, &#39;modulez&#39;: 0.02, &#39;axis_tilt&#39;: 0, &#39;originx&#39;: 0, &#39;originy&#39;: 0}},
+   &#39;octfile&#39;: &#39;1axis_2021-06-17_1300.oct&#39;,
+   &#39;Results&#39;: [{&#39;rowWanted&#39;: 2,
+     &#39;modWanted&#39;: 5,
+     &#39;AnalysisObj&#39;: {&#39;octfile&#39;: &#39;1axis_2021-06-17_1300.oct&#39;, &#39;name&#39;: &#39;1axis_2021-06-17_1300&#39;, &#39;hpc&#39;: False, &#39;modWanted&#39;: 5, &#39;rowWanted&#39;: 2, &#39;Wm2Front&#39;: [895.5053333333334, 895.7779, 896.0497333333333, 898.7332, 898.7845333333333, 898.8358666666667, 898.8872333333334, 898.9385000000001], &#39;Wm2Back&#39;: [146.7011, 111.57029999999999, 99.84521666666666, 109.47816666666667, 131.9399, 171.2386, 233.62636666666666, 308.50913333333335, 379.0931666666667], &#39;backRatio&#39;: 0.209426649303398, &#39;x&#39;: [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], &#39;y&#39;: [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], &#39;z&#39;: [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], &#39;mattype&#39;: [&#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;], &#39;rearMat&#39;: [&#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;]},
+     &#39;Wm2Front&#39;: [895.5053333333334,
+      895.7779,
+      896.0497333333333,
+      898.7332,
+      898.7845333333333,
+      898.8358666666667,
+      898.8872333333334,
+      898.9385000000001],
+     &#39;Wm2Back&#39;: [146.7011,
+      111.57029999999999,
+      99.84521666666666,
+      109.47816666666667,
+      131.9399,
+      171.2386,
+      233.62636666666666,
+      308.50913333333335,
+      379.0931666666667],
+     &#39;backRatio&#39;: 0.209426649303398}]},
+  &#39;2021-06-17_1400&#39;: {&#39;surf_azm&#39;: 30.0,
+   &#39;surf_tilt&#39;: 10.0,
+   &#39;theta&#39;: 10.0,
+   &#39;ghi&#39;: 702,
+   &#39;dhi&#39;: 306,
+   &#39;temp_air&#39;: 27.8,
+   &#39;wind_speed&#39;: 5.1,
+   &#39;skyfile&#39;: &#39;skies\\sky2_39.742_-105.179_2021-06-17_1400.rad&#39;,
+   &#39;clearance_height&#39;: 0.2,
+   &#39;radfile&#39;: &#39;objects\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;,
+   &#39;scene&#39;: {&#39;module&#39;: {&#39;x&#39;: 1.59, &#39;y&#39;: 0.95, &#39;z&#39;: 0.02, &#39;modulematerial&#39;: &#39;black&#39;, &#39;scenex&#39;: 1.59, &#39;sceney&#39;: 0.95, &#39;scenez&#39;: 0.0, &#39;numpanels&#39;: 1, &#39;bifi&#39;: 0.8, &#39;text&#39;: &#39;! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0&#39;, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;glass&#39;: False, &#39;offsetfromaxis&#39;: 0, &#39;xgap&#39;: 0.0, &#39;ygap&#39;: 0.0, &#39;zgap&#39;: 0.0}, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;hpc&#39;: False, &#39;gcr&#39;: 0.6333333333333333, &#39;text&#39;: &#39;!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\test-module.rad&#39;, &#39;radfiles&#39;: &#39;objects\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;, &#39;sceneDict&#39;: {&#39;tilt&#39;: 10.0, &#39;pitch&#39;: 1.5, &#39;clearance_height&#39;: 0.2, &#39;azimuth&#39;: 30.0, &#39;nMods&#39;: 10, &#39;nRows&#39;: 3, &#39;modulez&#39;: 0.02, &#39;axis_tilt&#39;: 0, &#39;originx&#39;: 0, &#39;originy&#39;: 0}},
+   &#39;octfile&#39;: &#39;1axis_2021-06-17_1400.oct&#39;,
+   &#39;Results&#39;: [{&#39;rowWanted&#39;: 2,
+     &#39;modWanted&#39;: 5,
+     &#39;AnalysisObj&#39;: {&#39;octfile&#39;: &#39;1axis_2021-06-17_1400.oct&#39;, &#39;name&#39;: &#39;1axis_2021-06-17_1400&#39;, &#39;hpc&#39;: False, &#39;modWanted&#39;: 5, &#39;rowWanted&#39;: 2, &#39;Wm2Front&#39;: [644.3194, 644.7297666666667, 645.1418333333332, 645.5538666666667, 645.9658666666666, 647.8394666666667, 647.9564333333333, 648.0749], &#39;Wm2Back&#39;: [117.00423333333333, 87.34127000000001, 87.59819333333333, 96.44088333333333, 114.32423333333334, 148.15723333333335, 192.7387, 242.80536666666663, 283.2325666666666], &#39;backRatio&#39;: 0.23550422178586114, &#39;x&#39;: [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], &#39;y&#39;: [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], &#39;z&#39;: [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], &#39;mattype&#39;: [&#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;], &#39;rearMat&#39;: [&#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;]},
+     &#39;Wm2Front&#39;: [644.3194,
+      644.7297666666667,
+      645.1418333333332,
+      645.5538666666667,
+      645.9658666666666,
+      647.8394666666667,
+      647.9564333333333,
+      648.0749],
+     &#39;Wm2Back&#39;: [117.00423333333333,
+      87.34127000000001,
+      87.59819333333333,
+      96.44088333333333,
+      114.32423333333334,
+      148.15723333333335,
+      192.7387,
+      242.80536666666663,
+      283.2325666666666],
+     &#39;backRatio&#39;: 0.23550422178586114}]}},
+ &#39;cumulativesky&#39;: False,
+ &#39;hub_height&#39;: 0.2}</pre>
 </div>
+
 </div>
 
 </div>

--- a/docs/tutorials/modelchain test.html
+++ b/docs/tutorials/modelchain test.html
@@ -14134,7 +14134,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[15]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[6]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">Params</span><span class="p">[</span><span class="mi">6</span><span class="p">][</span><span class="s1">&#39;modWanted&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span> <span class="mi">3</span><span class="p">]</span>
@@ -14148,7 +14148,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[16]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[7]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="p">,</span> <span class="n">analysis</span> <span class="o">=</span> <span class="n">bifacial_radiance</span><span class="o">.</span><span class="n">modelchain</span><span class="o">.</span><span class="n">runModelChain</span><span class="p">(</span><span class="o">*</span><span class="n">Params</span> <span class="p">)</span> 
@@ -14173,7 +14173,7 @@ a.anchor-link {
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
 <pre>
 New bifacial_radiance simulation starting. 
-Version:  0.4.1+14.g67db8ee.dirty
+Version:  0.4.1+15.gb7a948e.dirty
 path = C:\Users\sayala\Documents\GitHub\bifacial_radiance\bifacial_radiance\TEMP\Modelchain
 Loading times to restrict weather data to
 analysisParamsDict[&#39;modWanted&#39;] set to middle module by default
@@ -14207,19 +14207,15 @@ Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Front
 Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Back
 Saved: results\irr_1axis_2021-06-17_1300_Row2_Module5_Front.csv
 Saved: results\irr_1axis_2021-06-17_1300_Row2_Module5_Back.csv
-Index: 2021-06-17_1300. Wm2Front: 898.1953833333333. Wm2Back: 187.70051925925927
+Index: 2021-06-17_1300. Wm2Front: 898.4182666666667. Wm2Back: 188.6046951851852
 Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Front
 Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Back
 Saved: results\irr_1axis_2021-06-17_1400_Row2_Module5_Front.csv
 Saved: results\irr_1axis_2021-06-17_1400_Row2_Module5_Back.csv
-Index: 2021-06-17_1400. Wm2Front: 645.8340791666667. Wm2Back: 153.05764962962962
-Saving a cumulative-results file in the main simulation folder.This adds up by sensor location the irradiance over all hours or configurations considered. (last module/row pair only) 
-Warning: This file saving routine does not clean results, so if your setup has ygaps, or 2+modules or torque tubes, doing a deeper cleaning and working with the individual results files in the results folder is highly suggested.
-Not able to save a cumulative result for this simulation.
+Index: 2021-06-17_1400. Wm2Front: 646.4604708333333. Wm2Back: 153.67998259259258
 
 --&gt; Calculating Performance values
 Bifaciality factor of module stored is  0.8
-Exporting TrackerDict
 </pre>
 </div>
 </div>
@@ -14231,9 +14227,27 @@ Exporting TrackerDict
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>c:\users\sayala\documents\github\bifacial_radiance\bifacial_radiance\mismatch.py:220: FutureWarning: outer method for ufunc &lt;ufunc &#39;subtract&#39;&gt; is not implemented on pandas objects. Returning an ndarray, but in the future this will raise a &#39;NotImplementedError&#39;. Consider explicitly converting the DataFrame to an array with &#39;.to_numpy()&#39; first.
-  return (np.abs(np.subtract.outer(data,data)).sum()/float(data.__len__())**2 / np.mean(data))*100
-</pre>
+<pre>
+<span class="ansi-red-intense-fg ansi-bold">---------------------------------------------------------------------------</span>
+<span class="ansi-red-intense-fg ansi-bold">AttributeError</span>                            Traceback (most recent call last)
+<span class="ansi-green-intense-fg ansi-bold">~\AppData\Local\Temp\1/ipykernel_10944/1998972661.py</span> in <span class="ansi-cyan-fg">&lt;module&gt;</span>
+<span class="ansi-green-intense-fg ansi-bold">----&gt; 1</span><span class="ansi-yellow-intense-fg ansi-bold"> </span>demo2<span class="ansi-yellow-intense-fg ansi-bold">,</span> analysis <span class="ansi-yellow-intense-fg ansi-bold">=</span> bifacial_radiance<span class="ansi-yellow-intense-fg ansi-bold">.</span>modelchain<span class="ansi-yellow-intense-fg ansi-bold">.</span>runModelChain<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-yellow-intense-fg ansi-bold">*</span>Params <span class="ansi-yellow-intense-fg ansi-bold">)</span>
+
+<span class="ansi-green-intense-fg ansi-bold">c:\users\sayala\documents\github\bifacial_radiance\bifacial_radiance\modelchain.py</span> in <span class="ansi-cyan-fg">runModelChain</span><span class="ansi-blue-intense-fg ansi-bold">(simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellModuleDict, CECModParamsDict)</span>
+<span class="ansi-green-fg">    211</span>                 modfilter2 <span class="ansi-yellow-intense-fg ansi-bold">=</span> db<span class="ansi-yellow-intense-fg ansi-bold">.</span>index<span class="ansi-yellow-intense-fg ansi-bold">.</span>str<span class="ansi-yellow-intense-fg ansi-bold">.</span>startswith<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#39;Pr&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">)</span> <span class="ansi-yellow-intense-fg ansi-bold">&amp;</span> db<span class="ansi-yellow-intense-fg ansi-bold">.</span>index<span class="ansi-yellow-intense-fg ansi-bold">.</span>str<span class="ansi-yellow-intense-fg ansi-bold">.</span>endswith<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#39;BHC72-400&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">)</span>
+<span class="ansi-green-fg">    212</span>                 CECMod <span class="ansi-yellow-intense-fg ansi-bold">=</span> db<span class="ansi-yellow-intense-fg ansi-bold">[</span>modfilter2<span class="ansi-yellow-intense-fg ansi-bold">]</span>
+<span class="ansi-green-intense-fg ansi-bold">--&gt; 213</span><span class="ansi-yellow-intense-fg ansi-bold">             </span>demo<span class="ansi-yellow-intense-fg ansi-bold">.</span>calculateResults<span class="ansi-yellow-intense-fg ansi-bold">(</span>CECMod <span class="ansi-yellow-intense-fg ansi-bold">=</span> CECMod<span class="ansi-yellow-intense-fg ansi-bold">)</span>
+<span class="ansi-green-fg">    214</span>             demo<span class="ansi-yellow-intense-fg ansi-bold">.</span>exportTrackerDict<span class="ansi-yellow-intense-fg ansi-bold">(</span>savefile<span class="ansi-yellow-intense-fg ansi-bold">=</span>os<span class="ansi-yellow-intense-fg ansi-bold">.</span>path<span class="ansi-yellow-intense-fg ansi-bold">.</span>join<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#39;results&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">,</span><span class="ansi-blue-intense-fg ansi-bold">&#39;Final_Results.csv&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">)</span><span class="ansi-yellow-intense-fg ansi-bold">,</span>reindex<span class="ansi-yellow-intense-fg ansi-bold">=</span><span class="ansi-green-intense-fg ansi-bold">False</span><span class="ansi-yellow-intense-fg ansi-bold">)</span>
+<span class="ansi-green-fg">    215</span> 
+
+<span class="ansi-green-intense-fg ansi-bold">c:\users\sayala\documents\github\bifacial_radiance\bifacial_radiance\main.py</span> in <span class="ansi-cyan-fg">calculateResults</span><span class="ansi-blue-intense-fg ansi-bold">(self, CECMod, glassglass, bifacialityfactor, CECMod2)</span>
+<span class="ansi-green-fg">   2650</span>             print<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#34;Bifaciality factor of module stored is &#34;</span><span class="ansi-yellow-intense-fg ansi-bold">,</span> bifacialityfactor<span class="ansi-yellow-intense-fg ansi-bold">)</span>
+<span class="ansi-green-fg">   2651</span> 
+<span class="ansi-green-intense-fg ansi-bold">-&gt; 2652</span><span class="ansi-yellow-intense-fg ansi-bold">         </span><span class="ansi-green-intense-fg ansi-bold">if</span> self<span class="ansi-yellow-intense-fg ansi-bold">.</span>cumulative<span class="ansi-yellow-intense-fg ansi-bold">:</span>
+<span class="ansi-green-fg">   2653</span>             print<span class="ansi-yellow-intense-fg ansi-bold">(</span><span class="ansi-blue-intense-fg ansi-bold">&#34;Add HERE gencusky1axis results for each tracekr angle&#34;</span><span class="ansi-yellow-intense-fg ansi-bold">)</span>
+<span class="ansi-green-fg">   2654</span> 
+
+<span class="ansi-red-intense-fg ansi-bold">AttributeError</span>: &#39;RadianceObj&#39; object has no attribute &#39;cumulative&#39;</pre>
 </div>
 </div>
 
@@ -14242,141 +14256,12 @@ Exporting TrackerDict
 </div>
 
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[8]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span>
-</pre></div>
-
-     </div>
-</div>
-</div>
-</div>
-
-<div class="jp-Cell-outputWrapper">
-
-
-<div class="jp-OutputArea jp-Cell-outputArea">
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[8]:</div>
-
-
-
-
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>{&#39;2021-06-17_1300&#39;: {&#39;surf_azm&#39;: 30.0,
-  &#39;surf_tilt&#39;: 10.0,
-  &#39;theta&#39;: 10.0,
-  &#39;ghi&#39;: 959,
-  &#39;dhi&#39;: 172,
-  &#39;temp_air&#39;: 28.9,
-  &#39;wind_speed&#39;: 6.2,
-  &#39;skyfile&#39;: &#39;skies\\sky2_39.742_-105.179_2021-06-17_1300.rad&#39;,
-  &#39;clearance_height&#39;: 0.2,
-  &#39;radfile&#39;: &#39;objects\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;,
-  &#39;scene&#39;: {&#39;module&#39;: {&#39;x&#39;: 1.59, &#39;y&#39;: 0.95, &#39;z&#39;: 0.02, &#39;modulematerial&#39;: &#39;black&#39;, &#39;scenex&#39;: 1.59, &#39;sceney&#39;: 0.95, &#39;scenez&#39;: 0.0, &#39;numpanels&#39;: 1, &#39;bifi&#39;: 0.8, &#39;text&#39;: &#39;! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0&#39;, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;glass&#39;: False, &#39;offsetfromaxis&#39;: 0, &#39;xgap&#39;: 0.0, &#39;ygap&#39;: 0.0, &#39;zgap&#39;: 0.0}, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;hpc&#39;: False, &#39;gcr&#39;: 0.6333333333333333, &#39;text&#39;: &#39;!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\test-module.rad&#39;, &#39;radfiles&#39;: &#39;objects\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;, &#39;sceneDict&#39;: {&#39;tilt&#39;: 0, &#39;pitch&#39;: 1.5, &#39;clearance_height&#39;: 0.2, &#39;azimuth&#39;: 30.0, &#39;nMods&#39;: 10, &#39;nRows&#39;: 3, &#39;modulez&#39;: 0.02, &#39;axis_tilt&#39;: 0, &#39;originx&#39;: 0, &#39;originy&#39;: 0}},
-  &#39;octfile&#39;: &#39;1axis_2021-06-17_1300.oct&#39;,
-  &#39;Results&#39;: [{&#39;rowWanted&#39;: 2,
-    &#39;modWanted&#39;: 5,
-    &#39;AnalysisObj&#39;: {&#39;octfile&#39;: &#39;1axis_2021-06-17_1300.oct&#39;, &#39;name&#39;: &#39;1axis_2021-06-17_1300&#39;, &#39;hpc&#39;: False, &#39;modWanted&#39;: 5, &#39;rowWanted&#39;: 2, &#39;Wm2Front&#39;: [896.0219999999999, 895.7497333333332, 895.4763999999999, 899.9404666666666, 899.9072, 899.8732999999999, 899.8394666666667, 899.8056666666666], &#39;Wm2Back&#39;: [148.30476666666667, 110.41460000000001, 103.01362666666667, 108.25406666666667, 131.30333333333334, 172.55966666666666, 229.1205666666667, 310.21240000000006, 380.3414], &#39;backRatio&#39;: 0.20946628291434558, &#39;x&#39;: [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], &#39;y&#39;: [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], &#39;z&#39;: [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], &#39;mattype&#39;: [&#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;], &#39;rearMat&#39;: [&#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;]},
-    &#39;Wm2Front&#39;: [896.0219999999999,
-     895.7497333333332,
-     895.4763999999999,
-     899.9404666666666,
-     899.9072,
-     899.8732999999999,
-     899.8394666666667,
-     899.8056666666666],
-    &#39;Wm2Back&#39;: [148.30476666666667,
-     110.41460000000001,
-     103.01362666666667,
-     108.25406666666667,
-     131.30333333333334,
-     172.55966666666666,
-     229.1205666666667,
-     310.21240000000006,
-     380.3414],
-    &#39;backRatio&#39;: 0.20946628291434558}],
-  &#39;POA_eff&#39;: 1048.8622837592593,
-  &#39;Gfront_mean&#39;: 898.3267791666665,
-  &#39;Grear_mean&#39;: 188.16938074074076,
-  &#39;Pout_module&#39;: 379.6638001542193,
-  &#39;Mismatch&#39;: 0.06581846071414255,
-  &#39;Pout_module_reduced&#39;: 379.413911285069},
- &#39;2021-06-17_1400&#39;: {&#39;surf_azm&#39;: 30.0,
-  &#39;surf_tilt&#39;: 10.0,
-  &#39;theta&#39;: 10.0,
-  &#39;ghi&#39;: 702,
-  &#39;dhi&#39;: 306,
-  &#39;temp_air&#39;: 27.8,
-  &#39;wind_speed&#39;: 5.1,
-  &#39;skyfile&#39;: &#39;skies\\sky2_39.742_-105.179_2021-06-17_1400.rad&#39;,
-  &#39;clearance_height&#39;: 0.2,
-  &#39;radfile&#39;: &#39;objects\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;,
-  &#39;scene&#39;: {&#39;module&#39;: {&#39;x&#39;: 1.59, &#39;y&#39;: 0.95, &#39;z&#39;: 0.02, &#39;modulematerial&#39;: &#39;black&#39;, &#39;scenex&#39;: 1.59, &#39;sceney&#39;: 0.95, &#39;scenez&#39;: 0.0, &#39;numpanels&#39;: 1, &#39;bifi&#39;: 0.8, &#39;text&#39;: &#39;! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0&#39;, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;glass&#39;: False, &#39;offsetfromaxis&#39;: 0, &#39;xgap&#39;: 0.0, &#39;ygap&#39;: 0.0, &#39;zgap&#39;: 0.0}, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;hpc&#39;: False, &#39;gcr&#39;: 0.6333333333333333, &#39;text&#39;: &#39;!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\test-module.rad&#39;, &#39;radfiles&#39;: &#39;objects\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;, &#39;sceneDict&#39;: {&#39;tilt&#39;: 10.0, &#39;pitch&#39;: 1.5, &#39;clearance_height&#39;: 0.2, &#39;azimuth&#39;: 30.0, &#39;nMods&#39;: 10, &#39;nRows&#39;: 3, &#39;modulez&#39;: 0.02, &#39;axis_tilt&#39;: 0, &#39;originx&#39;: 0, &#39;originy&#39;: 0}},
-  &#39;octfile&#39;: &#39;1axis_2021-06-17_1400.oct&#39;,
-  &#39;Results&#39;: [{&#39;rowWanted&#39;: 2,
-    &#39;modWanted&#39;: 5,
-    &#39;AnalysisObj&#39;: {&#39;octfile&#39;: &#39;1axis_2021-06-17_1400.oct&#39;, &#39;name&#39;: &#39;1axis_2021-06-17_1400&#39;, &#39;hpc&#39;: False, &#39;modWanted&#39;: 5, &#39;rowWanted&#39;: 2, &#39;Wm2Front&#39;: [643.2881000000001, 643.6341666666667, 643.9813666666665, 646.7371, 646.8992666666667, 647.0624666666668, 647.2256000000001, 649.5095666666666], &#39;Wm2Back&#39;: [119.69326666666667, 94.68362333333334, 86.35244999999999, 95.52069333333334, 117.2034, 149.02993333333333, 193.71370000000002, 243.32743333333335, 284.2796666666667], &#39;backRatio&#39;: 0.23799649547718552, &#39;x&#39;: [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], &#39;y&#39;: [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], &#39;z&#39;: [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], &#39;mattype&#39;: [&#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;], &#39;rearMat&#39;: [&#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;]},
-    &#39;Wm2Front&#39;: [643.2881000000001,
-     643.6341666666667,
-     643.9813666666665,
-     646.7371,
-     646.8992666666667,
-     647.0624666666668,
-     647.2256000000001,
-     649.5095666666666],
-    &#39;Wm2Back&#39;: [119.69326666666667,
-     94.68362333333334,
-     86.35244999999999,
-     95.52069333333334,
-     117.2034,
-     149.02993333333333,
-     193.71370000000002,
-     243.32743333333335,
-     284.2796666666667],
-    &#39;backRatio&#39;: 0.23799649547718552}],
-  &#39;POA_eff&#39;: 769.0470189814815,
-  &#39;Gfront_mean&#39;: 646.0422041666667,
-  &#39;Grear_mean&#39;: 153.75601851851854,
-  &#39;Pout_module&#39;: 286.41613980714925,
-  &#39;Mismatch&#39;: 0.1046380322450241,
-  &#39;Pout_module_reduced&#39;: 286.1164395944229}}</pre>
-</div>
-
-</div>
-
-</div>
-
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[9]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">trackerdict</span> <span class="o">=</span> <span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span>
-<span class="n">keys</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="o">.</span><span class="n">keys</span><span class="p">())</span>
-</pre></div>
-
-     </div>
-</div>
-</div>
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[10]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">frontirrad</span> <span class="o">=</span> <span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span>
 </pre></div>
 
      </div>
@@ -14398,16 +14283,87 @@ Exporting TrackerDict
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
 <pre>
 <span class="ansi-red-intense-fg ansi-bold">---------------------------------------------------------------------------</span>
-<span class="ansi-red-intense-fg ansi-bold">KeyError</span>                                  Traceback (most recent call last)
-<span class="ansi-green-intense-fg ansi-bold">~\AppData\Local\Temp\1/ipykernel_2520/949070538.py</span> in <span class="ansi-cyan-fg">&lt;module&gt;</span>
-<span class="ansi-green-intense-fg ansi-bold">----&gt; 1</span><span class="ansi-yellow-intense-fg ansi-bold"> </span>frontirrad <span class="ansi-yellow-intense-fg ansi-bold">=</span> trackerdict<span class="ansi-yellow-intense-fg ansi-bold">[</span>keys<span class="ansi-yellow-intense-fg ansi-bold">[</span><span class="ansi-cyan-intense-fg ansi-bold">0</span><span class="ansi-yellow-intense-fg ansi-bold">]</span><span class="ansi-yellow-intense-fg ansi-bold">]</span><span class="ansi-yellow-intense-fg ansi-bold">[</span><span class="ansi-blue-intense-fg ansi-bold">&#39;AnalysisObj&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">]</span><span class="ansi-yellow-intense-fg ansi-bold">.</span>Wm2Front
+<span class="ansi-red-intense-fg ansi-bold">NameError</span>                                 Traceback (most recent call last)
+<span class="ansi-green-intense-fg ansi-bold">~\AppData\Local\Temp\1/ipykernel_10944/1149153798.py</span> in <span class="ansi-cyan-fg">&lt;module&gt;</span>
+<span class="ansi-green-intense-fg ansi-bold">----&gt; 1</span><span class="ansi-yellow-intense-fg ansi-bold"> </span>demo2
 
-<span class="ansi-red-intense-fg ansi-bold">KeyError</span>: &#39;AnalysisObj&#39;</pre>
+<span class="ansi-red-intense-fg ansi-bold">NameError</span>: name &#39;demo2&#39; is not defined</pre>
 </div>
 </div>
 
 </div>
 
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="o">.</span><span class="n">results</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">trackerdict</span> <span class="o">=</span> <span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span>
+<span class="n">keys</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="o">.</span><span class="n">keys</span><span class="p">())</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">frontirrad</span> <span class="o">=</span> <span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
 </div>
 
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">

--- a/docs/tutorials/modelchain test.html
+++ b/docs/tutorials/modelchain test.html
@@ -13971,7 +13971,7 @@ a.anchor-link {
 <div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[2]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[1]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">bifacial_radiance</span>
@@ -13987,7 +13987,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[3]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[2]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">inifile</span> <span class="o">=</span> <span class="sa">r</span><span class="s1">&#39;C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\ini_highAzimuth.ini&#39;</span>
@@ -14006,7 +14006,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[4]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[3]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="p">(</span><span class="n">Params</span><span class="p">)</span><span class="o">=</span> <span class="n">bifacial_radiance</span><span class="o">.</span><span class="n">load</span><span class="o">.</span><span class="n">readconfigurationinputfile</span><span class="p">(</span><span class="n">inifile</span><span class="o">=</span><span class="n">inifile</span><span class="p">)</span>
@@ -14041,7 +14041,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[5]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[4]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">Params</span>
@@ -14060,7 +14060,7 @@ a.anchor-link {
 <div class="jp-OutputArea-child">
 
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[5]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[4]:</div>
 
 
 
@@ -14118,7 +14118,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[6]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[5]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">Params</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">&#39;testfolder&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="n">testfolder</span>
@@ -14131,10 +14131,24 @@ a.anchor-link {
 </div>
 </div>
 
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[15]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">Params</span><span class="p">[</span><span class="mi">6</span><span class="p">][</span><span class="s1">&#39;modWanted&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span> <span class="mi">3</span><span class="p">]</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[7]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[16]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="p">,</span> <span class="n">analysis</span> <span class="o">=</span> <span class="n">bifacial_radiance</span><span class="o">.</span><span class="n">modelchain</span><span class="o">.</span><span class="n">runModelChain</span><span class="p">(</span><span class="o">*</span><span class="n">Params</span> <span class="p">)</span> 
@@ -14159,9 +14173,10 @@ a.anchor-link {
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
 <pre>
 New bifacial_radiance simulation starting. 
-Version:  0.4.0-dev2+20.g4dfb2bf.dirty
+Version:  0.4.1+14.g67db8ee.dirty
 path = C:\Users\sayala\Documents\GitHub\bifacial_radiance\bifacial_radiance\TEMP\Modelchain
 Loading times to restrict weather data to
+analysisParamsDict[&#39;modWanted&#39;] set to middle module by default
 Reading weather file C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\724666TYA.csv
 Warning: CSV file passed for input. Assuming it is TMY3style format
 8760 line in WeatherFile. Assuming this is a standard hourly WeatherFile for the year for purposes of saving Gencumulativesky temporary weather files in EPW folder.
@@ -14188,17 +14203,17 @@ Making ~2 .rad files for gendaylit 1-axis workflow (this takes a minute..)
 Making 2 octfiles in root directory.
 Created 1axis_2021-06-17_1300.oct
 Created 1axis_2021-06-17_1400.oct
-Linescan in process: 1axis_2021-06-17_1300_Front
-Linescan in process: 1axis_2021-06-17_1300_Back
-Saved: results\irr_1axis_2021-06-17_1300_Front.csv
-Saved: results\irr_1axis_2021-06-17_1300_Back.csv
-Index: 2021-06-17_1300. Wm2Front: 898.5004208333334. Wm2Back: 188.68636074074075
-Linescan in process: 1axis_2021-06-17_1400_Front
-Linescan in process: 1axis_2021-06-17_1400_Back
-Saved: results\irr_1axis_2021-06-17_1400_Front.csv
-Saved: results\irr_1axis_2021-06-17_1400_Back.csv
-Index: 2021-06-17_1400. Wm2Front: 646.5643125. Wm2Back: 153.1178651851852
-Saving a cumulative-results file in the main simulation folder.This adds up by sensor location the irradiance over all hours or configurations considered.
+Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Front
+Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Back
+Saved: results\irr_1axis_2021-06-17_1300_Row2_Module5_Front.csv
+Saved: results\irr_1axis_2021-06-17_1300_Row2_Module5_Back.csv
+Index: 2021-06-17_1300. Wm2Front: 898.1953833333333. Wm2Back: 187.70051925925927
+Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Front
+Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Back
+Saved: results\irr_1axis_2021-06-17_1400_Row2_Module5_Front.csv
+Saved: results\irr_1axis_2021-06-17_1400_Row2_Module5_Back.csv
+Index: 2021-06-17_1400. Wm2Front: 645.8340791666667. Wm2Back: 153.05764962962962
+Saving a cumulative-results file in the main simulation folder.This adds up by sensor location the irradiance over all hours or configurations considered. (last module/row pair only) 
 Warning: This file saving routine does not clean results, so if your setup has ygaps, or 2+modules or torque tubes, doing a deeper cleaning and working with the individual results files in the results folder is highly suggested.
 Not able to save a cumulative result for this simulation.
 
@@ -14226,10 +14241,10 @@ Exporting TrackerDict
 
 </div>
 
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[8]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span>
@@ -14240,10 +14255,110 @@ Exporting TrackerDict
 </div>
 </div>
 
+<div class="jp-Cell-outputWrapper">
+
+
+<div class="jp-OutputArea jp-Cell-outputArea">
+
+<div class="jp-OutputArea-child">
+
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[8]:</div>
+
+
+
+
+<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
+<pre>{&#39;2021-06-17_1300&#39;: {&#39;surf_azm&#39;: 30.0,
+  &#39;surf_tilt&#39;: 10.0,
+  &#39;theta&#39;: 10.0,
+  &#39;ghi&#39;: 959,
+  &#39;dhi&#39;: 172,
+  &#39;temp_air&#39;: 28.9,
+  &#39;wind_speed&#39;: 6.2,
+  &#39;skyfile&#39;: &#39;skies\\sky2_39.742_-105.179_2021-06-17_1300.rad&#39;,
+  &#39;clearance_height&#39;: 0.2,
+  &#39;radfile&#39;: &#39;objects\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;,
+  &#39;scene&#39;: {&#39;module&#39;: {&#39;x&#39;: 1.59, &#39;y&#39;: 0.95, &#39;z&#39;: 0.02, &#39;modulematerial&#39;: &#39;black&#39;, &#39;scenex&#39;: 1.59, &#39;sceney&#39;: 0.95, &#39;scenez&#39;: 0.0, &#39;numpanels&#39;: 1, &#39;bifi&#39;: 0.8, &#39;text&#39;: &#39;! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0&#39;, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;glass&#39;: False, &#39;offsetfromaxis&#39;: 0, &#39;xgap&#39;: 0.0, &#39;ygap&#39;: 0.0, &#39;zgap&#39;: 0.0}, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;hpc&#39;: False, &#39;gcr&#39;: 0.6333333333333333, &#39;text&#39;: &#39;!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\test-module.rad&#39;, &#39;radfiles&#39;: &#39;objects\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;, &#39;sceneDict&#39;: {&#39;tilt&#39;: 0, &#39;pitch&#39;: 1.5, &#39;clearance_height&#39;: 0.2, &#39;azimuth&#39;: 30.0, &#39;nMods&#39;: 10, &#39;nRows&#39;: 3, &#39;modulez&#39;: 0.02, &#39;axis_tilt&#39;: 0, &#39;originx&#39;: 0, &#39;originy&#39;: 0}},
+  &#39;octfile&#39;: &#39;1axis_2021-06-17_1300.oct&#39;,
+  &#39;Results&#39;: [{&#39;rowWanted&#39;: 2,
+    &#39;modWanted&#39;: 5,
+    &#39;AnalysisObj&#39;: {&#39;octfile&#39;: &#39;1axis_2021-06-17_1300.oct&#39;, &#39;name&#39;: &#39;1axis_2021-06-17_1300&#39;, &#39;hpc&#39;: False, &#39;modWanted&#39;: 5, &#39;rowWanted&#39;: 2, &#39;Wm2Front&#39;: [896.0219999999999, 895.7497333333332, 895.4763999999999, 899.9404666666666, 899.9072, 899.8732999999999, 899.8394666666667, 899.8056666666666], &#39;Wm2Back&#39;: [148.30476666666667, 110.41460000000001, 103.01362666666667, 108.25406666666667, 131.30333333333334, 172.55966666666666, 229.1205666666667, 310.21240000000006, 380.3414], &#39;backRatio&#39;: 0.20946628291434558, &#39;x&#39;: [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], &#39;y&#39;: [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], &#39;z&#39;: [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], &#39;mattype&#39;: [&#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;], &#39;rearMat&#39;: [&#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;]},
+    &#39;Wm2Front&#39;: [896.0219999999999,
+     895.7497333333332,
+     895.4763999999999,
+     899.9404666666666,
+     899.9072,
+     899.8732999999999,
+     899.8394666666667,
+     899.8056666666666],
+    &#39;Wm2Back&#39;: [148.30476666666667,
+     110.41460000000001,
+     103.01362666666667,
+     108.25406666666667,
+     131.30333333333334,
+     172.55966666666666,
+     229.1205666666667,
+     310.21240000000006,
+     380.3414],
+    &#39;backRatio&#39;: 0.20946628291434558}],
+  &#39;POA_eff&#39;: 1048.8622837592593,
+  &#39;Gfront_mean&#39;: 898.3267791666665,
+  &#39;Grear_mean&#39;: 188.16938074074076,
+  &#39;Pout_module&#39;: 379.6638001542193,
+  &#39;Mismatch&#39;: 0.06581846071414255,
+  &#39;Pout_module_reduced&#39;: 379.413911285069},
+ &#39;2021-06-17_1400&#39;: {&#39;surf_azm&#39;: 30.0,
+  &#39;surf_tilt&#39;: 10.0,
+  &#39;theta&#39;: 10.0,
+  &#39;ghi&#39;: 702,
+  &#39;dhi&#39;: 306,
+  &#39;temp_air&#39;: 27.8,
+  &#39;wind_speed&#39;: 5.1,
+  &#39;skyfile&#39;: &#39;skies\\sky2_39.742_-105.179_2021-06-17_1400.rad&#39;,
+  &#39;clearance_height&#39;: 0.2,
+  &#39;radfile&#39;: &#39;objects\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;,
+  &#39;scene&#39;: {&#39;module&#39;: {&#39;x&#39;: 1.59, &#39;y&#39;: 0.95, &#39;z&#39;: 0.02, &#39;modulematerial&#39;: &#39;black&#39;, &#39;scenex&#39;: 1.59, &#39;sceney&#39;: 0.95, &#39;scenez&#39;: 0.0, &#39;numpanels&#39;: 1, &#39;bifi&#39;: 0.8, &#39;text&#39;: &#39;! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0&#39;, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;glass&#39;: False, &#39;offsetfromaxis&#39;: 0, &#39;xgap&#39;: 0.0, &#39;ygap&#39;: 0.0, &#39;zgap&#39;: 0.0}, &#39;modulefile&#39;: &#39;objects\\test-module.rad&#39;, &#39;hpc&#39;: False, &#39;gcr&#39;: 0.6333333333333333, &#39;text&#39;: &#39;!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\test-module.rad&#39;, &#39;radfiles&#39;: &#39;objects\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad&#39;, &#39;sceneDict&#39;: {&#39;tilt&#39;: 10.0, &#39;pitch&#39;: 1.5, &#39;clearance_height&#39;: 0.2, &#39;azimuth&#39;: 30.0, &#39;nMods&#39;: 10, &#39;nRows&#39;: 3, &#39;modulez&#39;: 0.02, &#39;axis_tilt&#39;: 0, &#39;originx&#39;: 0, &#39;originy&#39;: 0}},
+  &#39;octfile&#39;: &#39;1axis_2021-06-17_1400.oct&#39;,
+  &#39;Results&#39;: [{&#39;rowWanted&#39;: 2,
+    &#39;modWanted&#39;: 5,
+    &#39;AnalysisObj&#39;: {&#39;octfile&#39;: &#39;1axis_2021-06-17_1400.oct&#39;, &#39;name&#39;: &#39;1axis_2021-06-17_1400&#39;, &#39;hpc&#39;: False, &#39;modWanted&#39;: 5, &#39;rowWanted&#39;: 2, &#39;Wm2Front&#39;: [643.2881000000001, 643.6341666666667, 643.9813666666665, 646.7371, 646.8992666666667, 647.0624666666668, 647.2256000000001, 649.5095666666666], &#39;Wm2Back&#39;: [119.69326666666667, 94.68362333333334, 86.35244999999999, 95.52069333333334, 117.2034, 149.02993333333333, 193.71370000000002, 243.32743333333335, 284.2796666666667], &#39;backRatio&#39;: 0.23799649547718552, &#39;x&#39;: [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], &#39;y&#39;: [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], &#39;z&#39;: [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], &#39;mattype&#39;: [&#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;, &#39;a4.1.a0.test-module.6457&#39;], &#39;rearMat&#39;: [&#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;, &#39;a4.1.a0.test-module.2310&#39;]},
+    &#39;Wm2Front&#39;: [643.2881000000001,
+     643.6341666666667,
+     643.9813666666665,
+     646.7371,
+     646.8992666666667,
+     647.0624666666668,
+     647.2256000000001,
+     649.5095666666666],
+    &#39;Wm2Back&#39;: [119.69326666666667,
+     94.68362333333334,
+     86.35244999999999,
+     95.52069333333334,
+     117.2034,
+     149.02993333333333,
+     193.71370000000002,
+     243.32743333333335,
+     284.2796666666667],
+    &#39;backRatio&#39;: 0.23799649547718552}],
+  &#39;POA_eff&#39;: 769.0470189814815,
+  &#39;Gfront_mean&#39;: 646.0422041666667,
+  &#39;Grear_mean&#39;: 153.75601851851854,
+  &#39;Pout_module&#39;: 286.41613980714925,
+  &#39;Mismatch&#39;: 0.1046380322450241,
+  &#39;Pout_module_reduced&#39;: 286.1164395944229}}</pre>
+</div>
+
+</div>
+
+</div>
+
+</div>
+
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[9]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">trackerdict</span> <span class="o">=</span> <span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span>
@@ -14255,10 +14370,10 @@ Exporting TrackerDict
 </div>
 </div>
 
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[10]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">frontirrad</span> <span class="o">=</span> <span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span>
@@ -14267,6 +14382,32 @@ Exporting TrackerDict
      </div>
 </div>
 </div>
+</div>
+
+<div class="jp-Cell-outputWrapper">
+
+
+<div class="jp-OutputArea jp-Cell-outputArea">
+
+<div class="jp-OutputArea-child">
+
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>
+<span class="ansi-red-intense-fg ansi-bold">---------------------------------------------------------------------------</span>
+<span class="ansi-red-intense-fg ansi-bold">KeyError</span>                                  Traceback (most recent call last)
+<span class="ansi-green-intense-fg ansi-bold">~\AppData\Local\Temp\1/ipykernel_2520/949070538.py</span> in <span class="ansi-cyan-fg">&lt;module&gt;</span>
+<span class="ansi-green-intense-fg ansi-bold">----&gt; 1</span><span class="ansi-yellow-intense-fg ansi-bold"> </span>frontirrad <span class="ansi-yellow-intense-fg ansi-bold">=</span> trackerdict<span class="ansi-yellow-intense-fg ansi-bold">[</span>keys<span class="ansi-yellow-intense-fg ansi-bold">[</span><span class="ansi-cyan-intense-fg ansi-bold">0</span><span class="ansi-yellow-intense-fg ansi-bold">]</span><span class="ansi-yellow-intense-fg ansi-bold">]</span><span class="ansi-yellow-intense-fg ansi-bold">[</span><span class="ansi-blue-intense-fg ansi-bold">&#39;AnalysisObj&#39;</span><span class="ansi-yellow-intense-fg ansi-bold">]</span><span class="ansi-yellow-intense-fg ansi-bold">.</span>Wm2Front
+
+<span class="ansi-red-intense-fg ansi-bold">KeyError</span>: &#39;AnalysisObj&#39;</pre>
+</div>
+</div>
+
+</div>
+
 </div>
 
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">

--- a/docs/tutorials/modelchain test.html
+++ b/docs/tutorials/modelchain test.html
@@ -13971,7 +13971,7 @@ a.anchor-link {
 <div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[1]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[2]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">bifacial_radiance</span>
@@ -13987,10 +13987,13 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[19]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[3]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">inifile</span> <span class="o">=</span> <span class="sa">r</span><span class="s1">&#39;C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\ini_highAzimuth.ini&#39;</span>
+<span class="c1">#inifile = r&#39;C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\ini_gencumsky.ini&#39;</span>
+<span class="c1">#inifile = r&#39;C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\ini_1axis.ini&#39;</span>
+
 <span class="n">weatherfile</span> <span class="o">=</span> <span class="sa">r</span><span class="s1">&#39;C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\724666TYA.csv&#39;</span>
 <span class="n">testfolder</span> <span class="o">=</span> <span class="sa">r</span><span class="s1">&#39;C:\Users\sayala\Documents\GitHub\bifacial_radiance\bifacial_radiance\TEMP\Modelchain&#39;</span>
 </pre></div>
@@ -14003,7 +14006,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[14]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[4]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="p">(</span><span class="n">Params</span><span class="p">)</span><span class="o">=</span> <span class="n">bifacial_radiance</span><span class="o">.</span><span class="n">load</span><span class="o">.</span><span class="n">readconfigurationinputfile</span><span class="p">(</span><span class="n">inifile</span><span class="o">=</span><span class="n">inifile</span><span class="p">)</span>
@@ -14038,10 +14041,10 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[15]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[5]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">Params</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">Params</span>
 </pre></div>
 
      </div>
@@ -14057,63 +14060,53 @@ a.anchor-link {
 <div class="jp-OutputArea-child">
 
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[15]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[5]:</div>
 
 
 
 
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>{&#39;weatherFile&#39;: &#39;724666TYA.CSV&#39;,
- &#39;getEPW&#39;: False,
- &#39;simulationname&#39;: &#39;_test_high_azimuth_angle_modelchain&#39;,
- &#39;moduletype&#39;: &#39;test-module&#39;,
- &#39;rewriteModule&#39;: True,
- &#39;cellLevelModule&#39;: False,
- &#39;axisofrotationTorqueTube&#39;: False,
- &#39;torqueTube&#39;: False,
- &#39;hpc&#39;: False,
- &#39;tracking&#39;: False,
- &#39;cumulativeSky&#39;: False,
- &#39;selectTimes&#39;: True,
- &#39;latitude&#39;: &#39;37.5&#39;,
- &#39;longitude&#39;: &#39;-77.6&#39;}</pre>
-</div>
-
-</div>
-
-</div>
-
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[16]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">Params</span><span class="p">[</span><span class="mi">2</span><span class="p">]</span>
-</pre></div>
-
-     </div>
-</div>
-</div>
-</div>
-
-<div class="jp-Cell-outputWrapper">
-
-
-<div class="jp-OutputArea jp-Cell-outputArea">
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[16]:</div>
-
-
-
-
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>{&#39;starttime&#39;: &#39;06_17_13&#39;, &#39;endtime&#39;: &#39;06_17_13&#39;}</pre>
+<pre>({&#39;weatherFile&#39;: &#39;724666TYA.CSV&#39;,
+  &#39;getEPW&#39;: False,
+  &#39;simulationname&#39;: &#39;_test_high_azimuth_angle_modelchain&#39;,
+  &#39;moduletype&#39;: &#39;test-module&#39;,
+  &#39;rewriteModule&#39;: True,
+  &#39;cellLevelModule&#39;: False,
+  &#39;axisofrotationTorqueTube&#39;: False,
+  &#39;torqueTube&#39;: False,
+  &#39;hpc&#39;: False,
+  &#39;tracking&#39;: False,
+  &#39;cumulativeSky&#39;: False,
+  &#39;selectTimes&#39;: True,
+  &#39;latitude&#39;: &#39;37.5&#39;,
+  &#39;longitude&#39;: &#39;-77.6&#39;},
+ {&#39;albedo&#39;: &#39;white_EPDM&#39;,
+  &#39;nMods&#39;: 10,
+  &#39;nRows&#39;: 3,
+  &#39;gcrorpitch&#39;: &#39;pitch&#39;,
+  &#39;pitch&#39;: 1.5,
+  &#39;azimuth&#39;: 30.0,
+  &#39;clearance_height&#39;: 0.2,
+  &#39;tilt&#39;: 10.0},
+ {&#39;starttime&#39;: &#39;06_17_13&#39;, &#39;endtime&#39;: &#39;06_17_13&#39;},
+ {&#39;bifi&#39;: 0.8,
+  &#39;numpanels&#39;: 1,
+  &#39;xgap&#39;: 0.0,
+  &#39;ygap&#39;: 0.0,
+  &#39;zgap&#39;: 0.0,
+  &#39;x&#39;: 1.59,
+  &#39;y&#39;: 0.95},
+ None,
+ None,
+ {&#39;sensorsy&#39;: (8, 9), &#39;modWanted&#39;: 5, &#39;rowWanted&#39;: 2},
+ None,
+ {&#39;alpha_sc&#39;: 0.0039216,
+  &#39;a_ref&#39;: 1.80227,
+  &#39;I_L_ref&#39;: 10.5308,
+  &#39;I_o_ref&#39;: 2.28e-11,
+  &#39;R_sh_ref&#39;: 900.982,
+  &#39;R_s&#39;: 0.285529,
+  &#39;Adjust&#39;: 4.39011})</pre>
 </div>
 
 </div>
@@ -14125,7 +14118,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[24]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[6]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">Params</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">&#39;testfolder&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="n">testfolder</span>
@@ -14141,7 +14134,7 @@ a.anchor-link {
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[25]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[7]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="p">,</span> <span class="n">analysis</span> <span class="o">=</span> <span class="n">bifacial_radiance</span><span class="o">.</span><span class="n">modelchain</span><span class="o">.</span><span class="n">runModelChain</span><span class="p">(</span><span class="o">*</span><span class="n">Params</span> <span class="p">)</span> 
@@ -14166,7 +14159,7 @@ a.anchor-link {
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
 <pre>
 New bifacial_radiance simulation starting. 
-Version:  0.4.0-dev2+15.geae1033
+Version:  0.4.0-dev2+20.g4dfb2bf.dirty
 path = C:\Users\sayala\Documents\GitHub\bifacial_radiance\bifacial_radiance\TEMP\Modelchain
 Loading times to restrict weather data to
 Reading weather file C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\724666TYA.csv
@@ -14199,15 +14192,32 @@ Linescan in process: 1axis_2021-06-17_1300_Front
 Linescan in process: 1axis_2021-06-17_1300_Back
 Saved: results\irr_1axis_2021-06-17_1300_Front.csv
 Saved: results\irr_1axis_2021-06-17_1300_Back.csv
-Index: 2021-06-17_1300. Wm2Front: 898.5218749999999. Wm2Back: 190.2805422222222
+Index: 2021-06-17_1300. Wm2Front: 898.5004208333334. Wm2Back: 188.68636074074075
 Linescan in process: 1axis_2021-06-17_1400_Front
 Linescan in process: 1axis_2021-06-17_1400_Back
 Saved: results\irr_1axis_2021-06-17_1400_Front.csv
 Saved: results\irr_1axis_2021-06-17_1400_Back.csv
-Index: 2021-06-17_1400. Wm2Front: 646.2458541666667. Wm2Back: 153.3900788888889
+Index: 2021-06-17_1400. Wm2Front: 646.5643125. Wm2Back: 153.1178651851852
 Saving a cumulative-results file in the main simulation folder.This adds up by sensor location the irradiance over all hours or configurations considered.
 Warning: This file saving routine does not clean results, so if your setup has ygaps, or 2+modules or torque tubes, doing a deeper cleaning and working with the individual results files in the results folder is highly suggested.
 Not able to save a cumulative result for this simulation.
+
+--&gt; Calculating Performance values
+Bifaciality factor of module stored is  0.8
+Exporting TrackerDict
+</pre>
+</div>
+</div>
+
+<div class="jp-OutputArea-child">
+
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>c:\users\sayala\documents\github\bifacial_radiance\bifacial_radiance\mismatch.py:220: FutureWarning: outer method for ufunc &lt;ufunc &#39;subtract&#39;&gt; is not implemented on pandas objects. Returning an ndarray, but in the future this will raise a &#39;NotImplementedError&#39;. Consider explicitly converting the DataFrame to an array with &#39;.to_numpy()&#39; first.
+  return (np.abs(np.subtract.outer(data,data)).sum()/float(data.__len__())**2 / np.mean(data))*100
 </pre>
 </div>
 </div>
@@ -14216,10 +14226,10 @@ Not able to save a cumulative result for this simulation.
 
 </div>
 
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[37]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span>
@@ -14230,33 +14240,53 @@ Not able to save a cumulative result for this simulation.
 </div>
 </div>
 
-<div class="jp-Cell-outputWrapper">
-
-
-<div class="jp-OutputArea jp-Cell-outputArea">
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[37]:</div>
-
-
-
-
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>dict_keys([&#39;2021-06-17_1300&#39;, &#39;2021-06-17_1400&#39;])</pre>
-</div>
-
-</div>
-
-</div>
-
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[39]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">trackerdict</span> <span class="o">=</span> <span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span>
+<span class="n">keys</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="o">.</span><span class="n">keys</span><span class="p">())</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">frontirrad</span> <span class="o">=</span> <span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="nb">type</span><span class="p">(</span><span class="n">frontirrad</span><span class="p">)</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1">#CEC Module</span>
@@ -14272,180 +14302,18 @@ Not able to save a cumulative result for this simulation.
 </div>
 </div>
 
-<div class="jp-Cell-outputWrapper">
-
-
-<div class="jp-OutputArea jp-Cell-outputArea">
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>1  modules selected. Name of 1st entry:  Prism Solar Technologies_ Inc. BHC72-400
-</pre>
-</div>
-</div>
-
-</div>
-
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[47]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">trackerdict</span> <span class="o">=</span> <span class="n">demo2</span><span class="o">.</span><span class="n">calculatePerformanceModule</span><span class="p">(</span><span class="n">CECMod</span><span class="p">)</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="nb">type</span><span class="p">(</span><span class="n">CECMod</span><span class="p">)</span>
 </pre></div>
 
      </div>
 </div>
 </div>
-</div>
-
-<div class="jp-Cell-outputWrapper">
-
-
-<div class="jp-OutputArea jp-Cell-outputArea">
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Bifaciality factor of module stored is  0.9
-</pre>
-</div>
-</div>
-
-</div>
-
-</div>
-
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[46]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="o">.</span><span class="n">exportTrackerDict</span><span class="p">(</span><span class="n">savefile</span><span class="o">=</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="s1">&#39;results&#39;</span><span class="p">,</span><span class="s1">&#39;Final_Results.csv&#39;</span><span class="p">),</span><span class="n">reindex</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
-<span class="n">pd</span><span class="o">.</span><span class="n">read_csv</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="s1">&#39;results&#39;</span><span class="p">,</span><span class="s1">&#39;Final_Results.csv&#39;</span><span class="p">))</span>
-</pre></div>
-
-     </div>
-</div>
-</div>
-</div>
-
-<div class="jp-Cell-outputWrapper">
-
-
-<div class="jp-OutputArea jp-Cell-outputArea">
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Exporting TrackerDict
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[46]:</div>
-
-
-
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html">
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>Unnamed: 0</th>
-      <th>dhi</th>
-      <th>ghi</th>
-      <th>Wm2Back</th>
-      <th>Wm2Front</th>
-      <th>theta</th>
-      <th>surf_tilt</th>
-      <th>surf_azm</th>
-      <th>clearance_height</th>
-      <th>effective_irradiance</th>
-      <th>Pout_module</th>
-      <th>Wm2BackAvg</th>
-      <th>Wm2FrontAvg</th>
-      <th>BifiRatio</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>2021-06-17_1300</td>
-      <td>172</td>
-      <td>959</td>
-      <td>[150.38653333333332, 112.35766666666666, 102.3...</td>
-      <td>[895.5752333333334, 895.5537333333333, 895.531...</td>
-      <td>10.0</td>
-      <td>10.0</td>
-      <td>30.0</td>
-      <td>0.2</td>
-      <td>1069.774363</td>
-      <td>386.325463</td>
-      <td>190.280542</td>
-      <td>898.521875</td>
-      <td>0.190594</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>2021-06-17_1400</td>
-      <td>306</td>
-      <td>702</td>
-      <td>[114.94426666666668, 93.72626666666666, 87.733...</td>
-      <td>[643.6093, 644.4763, 645.3445666666668, 647.03...</td>
-      <td>10.0</td>
-      <td>10.0</td>
-      <td>30.0</td>
-      <td>0.2</td>
-      <td>784.296925</td>
-      <td>291.653189</td>
-      <td>153.390079</td>
-      <td>646.245854</td>
-      <td>0.213620</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-</div>
-
-</div>
-
-</div>
-
 </div>
 
 </div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
@@ -14454,9 +14322,170 @@ Not able to save a cumulative result for this simulation.
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="c1">#assert np.round(np.mean(analysis.backRatio),2) == 0.20  # bifi ratio was == 0.22 in v0.2.2</span>
-<span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">mean</span><span class="p">(</span><span class="n">analysis</span><span class="o">.</span><span class="n">Wm2Front</span><span class="p">)</span> <span class="o">==</span> <span class="n">pytest</span><span class="o">.</span><span class="n">approx</span><span class="p">(</span><span class="mi">898</span><span class="p">,</span> <span class="n">rel</span> <span class="o">=</span> <span class="mf">0.005</span><span class="p">)</span>  <span class="c1"># was 912 in v0.2.3</span>
-<span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">mean</span><span class="p">(</span><span class="n">analysis</span><span class="o">.</span><span class="n">Wm2Back</span><span class="p">)</span> <span class="o">==</span> <span class="n">pytest</span><span class="o">.</span><span class="n">approx</span><span class="p">(</span><span class="mi">189</span><span class="p">,</span> <span class="n">rel</span> <span class="o">=</span> <span class="mf">0.02</span><span class="p">)</span>  <span class="c1"># was 182 in v0.2.2</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">CECModParamsDict</span> <span class="o">=</span> <span class="n">Params</span><span class="p">[</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">CECModParamsDict</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">pd</span><span class="o">.</span><span class="n">DataFrame</span><span class="p">(</span><span class="n">CECModParamsDict</span><span class="p">,</span> <span class="n">index</span><span class="o">=</span><span class="p">[</span><span class="mi">0</span><span class="p">])</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">numpy</span> <span class="k">as</span> <span class="nn">np</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">nan</span>
+<span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span><span class="p">[</span><span class="mi">2</span><span class="p">]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">nan</span>
+<span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span><span class="p">[</span><span class="mi">3</span><span class="p">]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">nan</span>
+<span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span><span class="p">[</span><span class="mi">4</span><span class="p">]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">nan</span>
+<span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span><span class="p">[</span><span class="mi">5</span><span class="p">]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">nan</span>
+<span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span><span class="p">[</span><span class="mi">6</span><span class="p">]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">nan</span>
+<span class="n">demo2</span><span class="o">.</span><span class="n">trackerdict</span><span class="p">[</span><span class="n">keys</span><span class="p">[</span><span class="mi">0</span><span class="p">]][</span><span class="s1">&#39;AnalysisObj&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">Wm2Front</span><span class="p">[</span><span class="mi">7</span><span class="p">]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">nan</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="nb">type</span><span class="p">(</span><span class="n">CECMod</span><span class="p">)</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">CECMod</span><span class="p">)</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">trackerdict</span> <span class="o">=</span> <span class="n">demo2</span><span class="o">.</span><span class="n">calculateResults</span><span class="p">(</span><span class="n">CECMod</span> <span class="o">=</span> <span class="n">CECMod</span><span class="p">)</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">CECMod</span><span class="o">.</span><span class="n">Adjust</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span>            <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Error: Mising/wrong parameters for CECMod, setting dictionary to None.&quot;</span><span class="p">,</span>
+                  <span class="s2">&quot;MAke sure to include alpha_sc, a_ref, I_L_ref, I_o_ref, &quot;</span><span class="p">,</span>
+                  <span class="s2">&quot;R_sh_ref, R_s, and Adjust&quot;</span>
+                  <span class="s2">&quot;Performance calculations, if performed, will use default module&quot;</span><span class="p">)</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">demo2</span><span class="o">.</span><span class="n">exportTrackerDict</span><span class="p">(</span><span class="n">savefile</span><span class="o">=</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="s1">&#39;results&#39;</span><span class="p">,</span><span class="s1">&#39;Final_Results.csv&#39;</span><span class="p">),</span><span class="n">reindex</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">pd</span><span class="o">.</span><span class="n">read_csv</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="s1">&#39;results&#39;</span><span class="p">,</span><span class="s1">&#39;Final_Results.csv&#39;</span><span class="p">))</span>
 </pre></div>
 
      </div>

--- a/docs/tutorials/modelchain test.ipynb
+++ b/docs/tutorials/modelchain test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "c15c77ea",
    "metadata": {},
    "outputs": [],
@@ -14,19 +14,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 3,
    "id": "b96adf39",
    "metadata": {},
    "outputs": [],
    "source": [
     "inifile = r'C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\tests\\ini_highAzimuth.ini'\n",
+    "#inifile = r'C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\tests\\ini_gencumsky.ini'\n",
+    "#inifile = r'C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\tests\\ini_1axis.ini'\n",
+    "\n",
     "weatherfile = r'C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\tests\\724666TYA.csv'\n",
     "testfolder = r'C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\bifacial_radiance\\TEMP\\Modelchain'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "id": "32cfa50d",
    "metadata": {},
    "outputs": [
@@ -44,62 +47,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "971babb1",
+   "execution_count": 5,
+   "id": "96f8b309",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'weatherFile': '724666TYA.CSV',\n",
-       " 'getEPW': False,\n",
-       " 'simulationname': '_test_high_azimuth_angle_modelchain',\n",
-       " 'moduletype': 'test-module',\n",
-       " 'rewriteModule': True,\n",
-       " 'cellLevelModule': False,\n",
-       " 'axisofrotationTorqueTube': False,\n",
-       " 'torqueTube': False,\n",
-       " 'hpc': False,\n",
-       " 'tracking': False,\n",
-       " 'cumulativeSky': False,\n",
-       " 'selectTimes': True,\n",
-       " 'latitude': '37.5',\n",
-       " 'longitude': '-77.6'}"
+       "({'weatherFile': '724666TYA.CSV',\n",
+       "  'getEPW': False,\n",
+       "  'simulationname': '_test_high_azimuth_angle_modelchain',\n",
+       "  'moduletype': 'test-module',\n",
+       "  'rewriteModule': True,\n",
+       "  'cellLevelModule': False,\n",
+       "  'axisofrotationTorqueTube': False,\n",
+       "  'torqueTube': False,\n",
+       "  'hpc': False,\n",
+       "  'tracking': False,\n",
+       "  'cumulativeSky': False,\n",
+       "  'selectTimes': True,\n",
+       "  'latitude': '37.5',\n",
+       "  'longitude': '-77.6'},\n",
+       " {'albedo': 'white_EPDM',\n",
+       "  'nMods': 10,\n",
+       "  'nRows': 3,\n",
+       "  'gcrorpitch': 'pitch',\n",
+       "  'pitch': 1.5,\n",
+       "  'azimuth': 30.0,\n",
+       "  'clearance_height': 0.2,\n",
+       "  'tilt': 10.0},\n",
+       " {'starttime': '06_17_13', 'endtime': '06_17_13'},\n",
+       " {'bifi': 0.8,\n",
+       "  'numpanels': 1,\n",
+       "  'xgap': 0.0,\n",
+       "  'ygap': 0.0,\n",
+       "  'zgap': 0.0,\n",
+       "  'x': 1.59,\n",
+       "  'y': 0.95},\n",
+       " None,\n",
+       " None,\n",
+       " {'sensorsy': (8, 9), 'modWanted': 5, 'rowWanted': 2},\n",
+       " None,\n",
+       " {'alpha_sc': 0.0039216,\n",
+       "  'a_ref': 1.80227,\n",
+       "  'I_L_ref': 10.5308,\n",
+       "  'I_o_ref': 2.28e-11,\n",
+       "  'R_sh_ref': 900.982,\n",
+       "  'R_s': 0.285529,\n",
+       "  'Adjust': 4.39011})"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Params[0]"
+    "Params"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "22f4e338",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'starttime': '06_17_13', 'endtime': '06_17_13'}"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Params[2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 6,
    "id": "eccc942e",
    "metadata": {},
    "outputs": [],
@@ -111,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 7,
    "id": "72cc6f26",
    "metadata": {},
    "outputs": [
@@ -121,7 +130,7 @@
      "text": [
       "\n",
       "New bifacial_radiance simulation starting. \n",
-      "Version:  0.4.0-dev2+15.geae1033\n",
+      "Version:  0.4.0-dev2+20.g4dfb2bf.dirty\n",
       "path = C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\bifacial_radiance\\TEMP\\Modelchain\n",
       "Loading times to restrict weather data to\n",
       "Reading weather file C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\tests\\724666TYA.csv\n",
@@ -154,15 +163,27 @@
       "Linescan in process: 1axis_2021-06-17_1300_Back\n",
       "Saved: results\\irr_1axis_2021-06-17_1300_Front.csv\n",
       "Saved: results\\irr_1axis_2021-06-17_1300_Back.csv\n",
-      "Index: 2021-06-17_1300. Wm2Front: 898.5218749999999. Wm2Back: 190.2805422222222\n",
+      "Index: 2021-06-17_1300. Wm2Front: 898.5004208333334. Wm2Back: 188.68636074074075\n",
       "Linescan in process: 1axis_2021-06-17_1400_Front\n",
       "Linescan in process: 1axis_2021-06-17_1400_Back\n",
       "Saved: results\\irr_1axis_2021-06-17_1400_Front.csv\n",
       "Saved: results\\irr_1axis_2021-06-17_1400_Back.csv\n",
-      "Index: 2021-06-17_1400. Wm2Front: 646.2458541666667. Wm2Back: 153.3900788888889\n",
+      "Index: 2021-06-17_1400. Wm2Front: 646.5643125. Wm2Back: 153.1178651851852\n",
       "Saving a cumulative-results file in the main simulation folder.This adds up by sensor location the irradiance over all hours or configurations considered.\n",
       "Warning: This file saving routine does not clean results, so if your setup has ygaps, or 2+modules or torque tubes, doing a deeper cleaning and working with the individual results files in the results folder is highly suggested.\n",
-      "Not able to save a cumulative result for this simulation.\n"
+      "Not able to save a cumulative result for this simulation.\n",
+      "\n",
+      "--> Calculating Performance values\n",
+      "Bifaciality factor of module stored is  0.8\n",
+      "Exporting TrackerDict\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\users\\sayala\\documents\\github\\bifacial_radiance\\bifacial_radiance\\mismatch.py:220: FutureWarning: outer method for ufunc <ufunc 'subtract'> is not implemented on pandas objects. Returning an ndarray, but in the future this will raise a 'NotImplementedError'. Consider explicitly converting the DataFrame to an array with '.to_numpy()' first.\n",
+      "  return (np.abs(np.subtract.outer(data,data)).sum()/float(data.__len__())**2 / np.mean(data))*100\n"
      ]
     }
    ],
@@ -172,39 +193,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "id": "dc349273",
+   "execution_count": null,
+   "id": "1f6ce352",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['2021-06-17_1300', '2021-06-17_1400'])"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "demo2.trackerdict"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
+   "id": "dc349273",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trackerdict = demo2.trackerdict\n",
+    "keys = list(demo2.trackerdict.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42c0c602",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frontirrad = trackerdict[keys[0]]['AnalysisObj'].Wm2Front"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57f60c2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(frontirrad)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ac9ed7a7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1  modules selected. Name of 1st entry:  Prism Solar Technologies_ Inc. BHC72-400\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#CEC Module\n",
     "url = 'https://raw.githubusercontent.com/NREL/SAM/patch/deploy/libraries/CEC%20Modules.csv'\n",
@@ -216,153 +249,141 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
-   "id": "007e404b",
+   "execution_count": null,
+   "id": "d558d1f2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bifaciality factor of module stored is  0.9\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "trackerdict = demo2.calculatePerformanceModule(CECMod)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "id": "739b65ae",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exporting TrackerDict\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Unnamed: 0</th>\n",
-       "      <th>dhi</th>\n",
-       "      <th>ghi</th>\n",
-       "      <th>Wm2Back</th>\n",
-       "      <th>Wm2Front</th>\n",
-       "      <th>theta</th>\n",
-       "      <th>surf_tilt</th>\n",
-       "      <th>surf_azm</th>\n",
-       "      <th>clearance_height</th>\n",
-       "      <th>effective_irradiance</th>\n",
-       "      <th>Pout_module</th>\n",
-       "      <th>Wm2BackAvg</th>\n",
-       "      <th>Wm2FrontAvg</th>\n",
-       "      <th>BifiRatio</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>2021-06-17_1300</td>\n",
-       "      <td>172</td>\n",
-       "      <td>959</td>\n",
-       "      <td>[150.38653333333332, 112.35766666666666, 102.3...</td>\n",
-       "      <td>[895.5752333333334, 895.5537333333333, 895.531...</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>30.0</td>\n",
-       "      <td>0.2</td>\n",
-       "      <td>1069.774363</td>\n",
-       "      <td>386.325463</td>\n",
-       "      <td>190.280542</td>\n",
-       "      <td>898.521875</td>\n",
-       "      <td>0.190594</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2021-06-17_1400</td>\n",
-       "      <td>306</td>\n",
-       "      <td>702</td>\n",
-       "      <td>[114.94426666666668, 93.72626666666666, 87.733...</td>\n",
-       "      <td>[643.6093, 644.4763, 645.3445666666668, 647.03...</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>30.0</td>\n",
-       "      <td>0.2</td>\n",
-       "      <td>784.296925</td>\n",
-       "      <td>291.653189</td>\n",
-       "      <td>153.390079</td>\n",
-       "      <td>646.245854</td>\n",
-       "      <td>0.213620</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        Unnamed: 0  dhi  ghi  \\\n",
-       "0  2021-06-17_1300  172  959   \n",
-       "1  2021-06-17_1400  306  702   \n",
-       "\n",
-       "                                             Wm2Back  \\\n",
-       "0  [150.38653333333332, 112.35766666666666, 102.3...   \n",
-       "1  [114.94426666666668, 93.72626666666666, 87.733...   \n",
-       "\n",
-       "                                            Wm2Front  theta  surf_tilt  \\\n",
-       "0  [895.5752333333334, 895.5537333333333, 895.531...   10.0       10.0   \n",
-       "1  [643.6093, 644.4763, 645.3445666666668, 647.03...   10.0       10.0   \n",
-       "\n",
-       "   surf_azm  clearance_height  effective_irradiance  Pout_module  Wm2BackAvg  \\\n",
-       "0      30.0               0.2           1069.774363   386.325463  190.280542   \n",
-       "1      30.0               0.2            784.296925   291.653189  153.390079   \n",
-       "\n",
-       "   Wm2FrontAvg  BifiRatio  \n",
-       "0   898.521875   0.190594  \n",
-       "1   646.245854   0.213620  "
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "demo2.exportTrackerDict(savefile=os.path.join('results','Final_Results.csv'),reindex=False)\n",
-    "pd.read_csv(os.path.join('results','Final_Results.csv'))"
+    "type(CECMod)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "428601d4",
+   "id": "190604fb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#assert np.round(np.mean(analysis.backRatio),2) == 0.20  # bifi ratio was == 0.22 in v0.2.2\n",
-    "assert np.mean(analysis.Wm2Front) == pytest.approx(898, rel = 0.005)  # was 912 in v0.2.3\n",
-    "assert np.mean(analysis.Wm2Back) == pytest.approx(189, rel = 0.02)  # was 182 in v0.2.2"
+    "CECModParamsDict = Params[-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f34740f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CECModParamsDict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3487e63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.DataFrame(CECModParamsDict, index=[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a4f0ce6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c55c2fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[1] = np.nan\n",
+    "demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[2] = np.nan\n",
+    "demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[3] = np.nan\n",
+    "demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[4] = np.nan\n",
+    "demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[5] = np.nan\n",
+    "demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[6] = np.nan\n",
+    "demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[7] = np.nan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a8bcd40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(CECMod)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f28459e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CECMod)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a34f3fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trackerdict = demo2.calculateResults(CECMod = CECMod)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3383267",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CECMod.Adjust"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93ccd8de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "            print(\"Error: Mising/wrong parameters for CECMod, setting dictionary to None.\",\n",
+    "                  \"MAke sure to include alpha_sc, a_ref, I_L_ref, I_o_ref, \",\n",
+    "                  \"R_sh_ref, R_s, and Adjust\"\n",
+    "                  \"Performance calculations, if performed, will use default module\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18353047",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demo2.exportTrackerDict(savefile=os.path.join('results','Final_Results.csv'),reindex=False)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6de88fd3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.read_csv(os.path.join('results','Final_Results.csv'))"
    ]
   }
  ],

--- a/docs/tutorials/modelchain test.ipynb
+++ b/docs/tutorials/modelchain test.ipynb
@@ -120,8 +120,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "58e536e6",
+   "execution_count": 6,
+   "id": "b9a7de53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "id": "72cc6f26",
    "metadata": {},
    "outputs": [
@@ -140,7 +140,7 @@
      "text": [
       "\n",
       "New bifacial_radiance simulation starting. \n",
-      "Version:  0.4.1+14.g67db8ee.dirty\n",
+      "Version:  0.4.1+15.gb7a948e.dirty\n",
       "path = C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\bifacial_radiance\\TEMP\\Modelchain\n",
       "Loading times to restrict weather data to\n",
       "analysisParamsDict['modWanted'] set to middle module by default\n",
@@ -174,27 +174,28 @@
       "Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Back\n",
       "Saved: results\\irr_1axis_2021-06-17_1300_Row2_Module5_Front.csv\n",
       "Saved: results\\irr_1axis_2021-06-17_1300_Row2_Module5_Back.csv\n",
-      "Index: 2021-06-17_1300. Wm2Front: 898.1953833333333. Wm2Back: 187.70051925925927\n",
+      "Index: 2021-06-17_1300. Wm2Front: 898.4182666666667. Wm2Back: 188.6046951851852\n",
       "Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Front\n",
       "Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Back\n",
       "Saved: results\\irr_1axis_2021-06-17_1400_Row2_Module5_Front.csv\n",
       "Saved: results\\irr_1axis_2021-06-17_1400_Row2_Module5_Back.csv\n",
-      "Index: 2021-06-17_1400. Wm2Front: 645.8340791666667. Wm2Back: 153.05764962962962\n",
-      "Saving a cumulative-results file in the main simulation folder.This adds up by sensor location the irradiance over all hours or configurations considered. (last module/row pair only) \n",
-      "Warning: This file saving routine does not clean results, so if your setup has ygaps, or 2+modules or torque tubes, doing a deeper cleaning and working with the individual results files in the results folder is highly suggested.\n",
-      "Not able to save a cumulative result for this simulation.\n",
+      "Index: 2021-06-17_1400. Wm2Front: 646.4604708333333. Wm2Back: 153.67998259259258\n",
       "\n",
       "--> Calculating Performance values\n",
-      "Bifaciality factor of module stored is  0.8\n",
-      "Exporting TrackerDict\n"
+      "Bifaciality factor of module stored is  0.8\n"
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\users\\sayala\\documents\\github\\bifacial_radiance\\bifacial_radiance\\mismatch.py:220: FutureWarning: outer method for ufunc <ufunc 'subtract'> is not implemented on pandas objects. Returning an ndarray, but in the future this will raise a 'NotImplementedError'. Consider explicitly converting the DataFrame to an array with '.to_numpy()' first.\n",
-      "  return (np.abs(np.subtract.outer(data,data)).sum()/float(data.__len__())**2 / np.mean(data))*100\n"
+     "ename": "AttributeError",
+     "evalue": "'RadianceObj' object has no attribute 'cumulative'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m~\\AppData\\Local\\Temp\\1/ipykernel_10944/1998972661.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mdemo2\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0manalysis\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mbifacial_radiance\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodelchain\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mrunModelChain\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mParams\u001b[0m \u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mc:\\users\\sayala\\documents\\github\\bifacial_radiance\\bifacial_radiance\\modelchain.py\u001b[0m in \u001b[0;36mrunModelChain\u001b[1;34m(simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellModuleDict, CECModParamsDict)\u001b[0m\n\u001b[0;32m    211\u001b[0m                 \u001b[0mmodfilter2\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mdb\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstr\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstartswith\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'Pr'\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m&\u001b[0m \u001b[0mdb\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstr\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mendswith\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'BHC72-400'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    212\u001b[0m                 \u001b[0mCECMod\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mdb\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mmodfilter2\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 213\u001b[1;33m             \u001b[0mdemo\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcalculateResults\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mCECMod\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mCECMod\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    214\u001b[0m             \u001b[0mdemo\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexportTrackerDict\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0msavefile\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mos\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'results'\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;34m'Final_Results.csv'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0mreindex\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mFalse\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    215\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mc:\\users\\sayala\\documents\\github\\bifacial_radiance\\bifacial_radiance\\main.py\u001b[0m in \u001b[0;36mcalculateResults\u001b[1;34m(self, CECMod, glassglass, bifacialityfactor, CECMod2)\u001b[0m\n\u001b[0;32m   2650\u001b[0m             \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Bifaciality factor of module stored is \"\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mbifacialityfactor\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   2651\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 2652\u001b[1;33m         \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcumulative\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   2653\u001b[0m             \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Add HERE gencusky1axis results for each tracekr angle\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   2654\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mAttributeError\u001b[0m: 'RadianceObj' object has no attribute 'cumulative'"
      ]
     }
    ],
@@ -204,105 +205,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "1f6ce352",
+   "execution_count": 9,
+   "id": "1231f96a",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'2021-06-17_1300': {'surf_azm': 30.0,\n",
-       "  'surf_tilt': 10.0,\n",
-       "  'theta': 10.0,\n",
-       "  'ghi': 959,\n",
-       "  'dhi': 172,\n",
-       "  'temp_air': 28.9,\n",
-       "  'wind_speed': 6.2,\n",
-       "  'skyfile': 'skies\\\\sky2_39.742_-105.179_2021-06-17_1300.rad',\n",
-       "  'clearance_height': 0.2,\n",
-       "  'radfile': 'objects\\\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad',\n",
-       "  'scene': {'module': {'x': 1.59, 'y': 0.95, 'z': 0.02, 'modulematerial': 'black', 'scenex': 1.59, 'sceney': 0.95, 'scenez': 0.0, 'numpanels': 1, 'bifi': 0.8, 'text': '! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0', 'modulefile': 'objects\\\\test-module.rad', 'glass': False, 'offsetfromaxis': 0, 'xgap': 0.0, 'ygap': 0.0, 'zgap': 0.0}, 'modulefile': 'objects\\\\test-module.rad', 'hpc': False, 'gcr': 0.6333333333333333, 'text': '!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\\\test-module.rad', 'radfiles': 'objects\\\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad', 'sceneDict': {'tilt': 0, 'pitch': 1.5, 'clearance_height': 0.2, 'azimuth': 30.0, 'nMods': 10, 'nRows': 3, 'modulez': 0.02, 'axis_tilt': 0, 'originx': 0, 'originy': 0}},\n",
-       "  'octfile': '1axis_2021-06-17_1300.oct',\n",
-       "  'Results': [{'rowWanted': 2,\n",
-       "    'modWanted': 5,\n",
-       "    'AnalysisObj': {'octfile': '1axis_2021-06-17_1300.oct', 'name': '1axis_2021-06-17_1300', 'hpc': False, 'modWanted': 5, 'rowWanted': 2, 'Wm2Front': [896.0219999999999, 895.7497333333332, 895.4763999999999, 899.9404666666666, 899.9072, 899.8732999999999, 899.8394666666667, 899.8056666666666], 'Wm2Back': [148.30476666666667, 110.41460000000001, 103.01362666666667, 108.25406666666667, 131.30333333333334, 172.55966666666666, 229.1205666666667, 310.21240000000006, 380.3414], 'backRatio': 0.20946628291434558, 'x': [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], 'y': [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], 'z': [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], 'mattype': ['a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457'], 'rearMat': ['a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310']},\n",
-       "    'Wm2Front': [896.0219999999999,\n",
-       "     895.7497333333332,\n",
-       "     895.4763999999999,\n",
-       "     899.9404666666666,\n",
-       "     899.9072,\n",
-       "     899.8732999999999,\n",
-       "     899.8394666666667,\n",
-       "     899.8056666666666],\n",
-       "    'Wm2Back': [148.30476666666667,\n",
-       "     110.41460000000001,\n",
-       "     103.01362666666667,\n",
-       "     108.25406666666667,\n",
-       "     131.30333333333334,\n",
-       "     172.55966666666666,\n",
-       "     229.1205666666667,\n",
-       "     310.21240000000006,\n",
-       "     380.3414],\n",
-       "    'backRatio': 0.20946628291434558}],\n",
-       "  'POA_eff': 1048.8622837592593,\n",
-       "  'Gfront_mean': 898.3267791666665,\n",
-       "  'Grear_mean': 188.16938074074076,\n",
-       "  'Pout_module': 379.6638001542193,\n",
-       "  'Mismatch': 0.06581846071414255,\n",
-       "  'Pout_module_reduced': 379.413911285069},\n",
-       " '2021-06-17_1400': {'surf_azm': 30.0,\n",
-       "  'surf_tilt': 10.0,\n",
-       "  'theta': 10.0,\n",
-       "  'ghi': 702,\n",
-       "  'dhi': 306,\n",
-       "  'temp_air': 27.8,\n",
-       "  'wind_speed': 5.1,\n",
-       "  'skyfile': 'skies\\\\sky2_39.742_-105.179_2021-06-17_1400.rad',\n",
-       "  'clearance_height': 0.2,\n",
-       "  'radfile': 'objects\\\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad',\n",
-       "  'scene': {'module': {'x': 1.59, 'y': 0.95, 'z': 0.02, 'modulematerial': 'black', 'scenex': 1.59, 'sceney': 0.95, 'scenez': 0.0, 'numpanels': 1, 'bifi': 0.8, 'text': '! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0', 'modulefile': 'objects\\\\test-module.rad', 'glass': False, 'offsetfromaxis': 0, 'xgap': 0.0, 'ygap': 0.0, 'zgap': 0.0}, 'modulefile': 'objects\\\\test-module.rad', 'hpc': False, 'gcr': 0.6333333333333333, 'text': '!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\\\test-module.rad', 'radfiles': 'objects\\\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad', 'sceneDict': {'tilt': 10.0, 'pitch': 1.5, 'clearance_height': 0.2, 'azimuth': 30.0, 'nMods': 10, 'nRows': 3, 'modulez': 0.02, 'axis_tilt': 0, 'originx': 0, 'originy': 0}},\n",
-       "  'octfile': '1axis_2021-06-17_1400.oct',\n",
-       "  'Results': [{'rowWanted': 2,\n",
-       "    'modWanted': 5,\n",
-       "    'AnalysisObj': {'octfile': '1axis_2021-06-17_1400.oct', 'name': '1axis_2021-06-17_1400', 'hpc': False, 'modWanted': 5, 'rowWanted': 2, 'Wm2Front': [643.2881000000001, 643.6341666666667, 643.9813666666665, 646.7371, 646.8992666666667, 647.0624666666668, 647.2256000000001, 649.5095666666666], 'Wm2Back': [119.69326666666667, 94.68362333333334, 86.35244999999999, 95.52069333333334, 117.2034, 149.02993333333333, 193.71370000000002, 243.32743333333335, 284.2796666666667], 'backRatio': 0.23799649547718552, 'x': [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], 'y': [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], 'z': [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], 'mattype': ['a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457'], 'rearMat': ['a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310']},\n",
-       "    'Wm2Front': [643.2881000000001,\n",
-       "     643.6341666666667,\n",
-       "     643.9813666666665,\n",
-       "     646.7371,\n",
-       "     646.8992666666667,\n",
-       "     647.0624666666668,\n",
-       "     647.2256000000001,\n",
-       "     649.5095666666666],\n",
-       "    'Wm2Back': [119.69326666666667,\n",
-       "     94.68362333333334,\n",
-       "     86.35244999999999,\n",
-       "     95.52069333333334,\n",
-       "     117.2034,\n",
-       "     149.02993333333333,\n",
-       "     193.71370000000002,\n",
-       "     243.32743333333335,\n",
-       "     284.2796666666667],\n",
-       "    'backRatio': 0.23799649547718552}],\n",
-       "  'POA_eff': 769.0470189814815,\n",
-       "  'Gfront_mean': 646.0422041666667,\n",
-       "  'Grear_mean': 153.75601851851854,\n",
-       "  'Pout_module': 286.41613980714925,\n",
-       "  'Mismatch': 0.1046380322450241,\n",
-       "  'Pout_module_reduced': 286.1164395944229}}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'demo2' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m~\\AppData\\Local\\Temp\\1/ipykernel_10944/1149153798.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mdemo2\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m: name 'demo2' is not defined"
+     ]
     }
    ],
    "source": [
-    "demo2.trackerdict"
+    "demo2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
+   "id": "886947cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demo2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a19e411",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demo2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f6ce352",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demo2.results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "dc349273",
    "metadata": {},
    "outputs": [],
@@ -313,22 +268,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "42c0c602",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "KeyError",
-     "evalue": "'AnalysisObj'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[1;32m~\\AppData\\Local\\Temp\\1/ipykernel_2520/949070538.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mfrontirrad\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mtrackerdict\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mkeys\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m'AnalysisObj'\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mWm2Front\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;31mKeyError\u001b[0m: 'AnalysisObj'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "frontirrad = trackerdict[keys[0]]['AnalysisObj'].Wm2Front"
    ]

--- a/docs/tutorials/modelchain test.ipynb
+++ b/docs/tutorials/modelchain test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "c15c77ea",
    "metadata": {},
    "outputs": [],
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "b96adf39",
    "metadata": {},
    "outputs": [],
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "32cfa50d",
    "metadata": {},
    "outputs": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "96f8b309",
    "metadata": {},
    "outputs": [
@@ -97,7 +97,7 @@
        "  'Adjust': 4.39011})"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "eccc942e",
    "metadata": {},
    "outputs": [],
@@ -120,7 +120,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 15,
+   "id": "58e536e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Params[6]['modWanted'] = [1, 3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "id": "72cc6f26",
    "metadata": {},
    "outputs": [
@@ -130,9 +140,10 @@
      "text": [
       "\n",
       "New bifacial_radiance simulation starting. \n",
-      "Version:  0.4.0-dev2+20.g4dfb2bf.dirty\n",
+      "Version:  0.4.1+14.g67db8ee.dirty\n",
       "path = C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\bifacial_radiance\\TEMP\\Modelchain\n",
       "Loading times to restrict weather data to\n",
+      "analysisParamsDict['modWanted'] set to middle module by default\n",
       "Reading weather file C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\tests\\724666TYA.csv\n",
       "Warning: CSV file passed for input. Assuming it is TMY3style format\n",
       "8760 line in WeatherFile. Assuming this is a standard hourly WeatherFile for the year for purposes of saving Gencumulativesky temporary weather files in EPW folder.\n",
@@ -159,17 +170,17 @@
       "Making 2 octfiles in root directory.\n",
       "Created 1axis_2021-06-17_1300.oct\n",
       "Created 1axis_2021-06-17_1400.oct\n",
-      "Linescan in process: 1axis_2021-06-17_1300_Front\n",
-      "Linescan in process: 1axis_2021-06-17_1300_Back\n",
-      "Saved: results\\irr_1axis_2021-06-17_1300_Front.csv\n",
-      "Saved: results\\irr_1axis_2021-06-17_1300_Back.csv\n",
-      "Index: 2021-06-17_1300. Wm2Front: 898.5004208333334. Wm2Back: 188.68636074074075\n",
-      "Linescan in process: 1axis_2021-06-17_1400_Front\n",
-      "Linescan in process: 1axis_2021-06-17_1400_Back\n",
-      "Saved: results\\irr_1axis_2021-06-17_1400_Front.csv\n",
-      "Saved: results\\irr_1axis_2021-06-17_1400_Back.csv\n",
-      "Index: 2021-06-17_1400. Wm2Front: 646.5643125. Wm2Back: 153.1178651851852\n",
-      "Saving a cumulative-results file in the main simulation folder.This adds up by sensor location the irradiance over all hours or configurations considered.\n",
+      "Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Front\n",
+      "Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Back\n",
+      "Saved: results\\irr_1axis_2021-06-17_1300_Row2_Module5_Front.csv\n",
+      "Saved: results\\irr_1axis_2021-06-17_1300_Row2_Module5_Back.csv\n",
+      "Index: 2021-06-17_1300. Wm2Front: 898.1953833333333. Wm2Back: 187.70051925925927\n",
+      "Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Front\n",
+      "Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Back\n",
+      "Saved: results\\irr_1axis_2021-06-17_1400_Row2_Module5_Front.csv\n",
+      "Saved: results\\irr_1axis_2021-06-17_1400_Row2_Module5_Back.csv\n",
+      "Index: 2021-06-17_1400. Wm2Front: 645.8340791666667. Wm2Back: 153.05764962962962\n",
+      "Saving a cumulative-results file in the main simulation folder.This adds up by sensor location the irradiance over all hours or configurations considered. (last module/row pair only) \n",
       "Warning: This file saving routine does not clean results, so if your setup has ygaps, or 2+modules or torque tubes, doing a deeper cleaning and working with the individual results files in the results folder is highly suggested.\n",
       "Not able to save a cumulative result for this simulation.\n",
       "\n",
@@ -188,22 +199,110 @@
     }
    ],
    "source": [
-    "demo2, analysis = bifacial_radiance.modelchain.runModelChain(*Params ) \n"
+    "demo2, analysis = bifacial_radiance.modelchain.runModelChain(*Params ) "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "1f6ce352",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'2021-06-17_1300': {'surf_azm': 30.0,\n",
+       "  'surf_tilt': 10.0,\n",
+       "  'theta': 10.0,\n",
+       "  'ghi': 959,\n",
+       "  'dhi': 172,\n",
+       "  'temp_air': 28.9,\n",
+       "  'wind_speed': 6.2,\n",
+       "  'skyfile': 'skies\\\\sky2_39.742_-105.179_2021-06-17_1300.rad',\n",
+       "  'clearance_height': 0.2,\n",
+       "  'radfile': 'objects\\\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad',\n",
+       "  'scene': {'module': {'x': 1.59, 'y': 0.95, 'z': 0.02, 'modulematerial': 'black', 'scenex': 1.59, 'sceney': 0.95, 'scenez': 0.0, 'numpanels': 1, 'bifi': 0.8, 'text': '! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0', 'modulefile': 'objects\\\\test-module.rad', 'glass': False, 'offsetfromaxis': 0, 'xgap': 0.0, 'ygap': 0.0, 'zgap': 0.0}, 'modulefile': 'objects\\\\test-module.rad', 'hpc': False, 'gcr': 0.6333333333333333, 'text': '!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\\\test-module.rad', 'radfiles': 'objects\\\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad', 'sceneDict': {'tilt': 0, 'pitch': 1.5, 'clearance_height': 0.2, 'azimuth': 30.0, 'nMods': 10, 'nRows': 3, 'modulez': 0.02, 'axis_tilt': 0, 'originx': 0, 'originy': 0}},\n",
+       "  'octfile': '1axis_2021-06-17_1300.oct',\n",
+       "  'Results': [{'rowWanted': 2,\n",
+       "    'modWanted': 5,\n",
+       "    'AnalysisObj': {'octfile': '1axis_2021-06-17_1300.oct', 'name': '1axis_2021-06-17_1300', 'hpc': False, 'modWanted': 5, 'rowWanted': 2, 'Wm2Front': [896.0219999999999, 895.7497333333332, 895.4763999999999, 899.9404666666666, 899.9072, 899.8732999999999, 899.8394666666667, 899.8056666666666], 'Wm2Back': [148.30476666666667, 110.41460000000001, 103.01362666666667, 108.25406666666667, 131.30333333333334, 172.55966666666666, 229.1205666666667, 310.21240000000006, 380.3414], 'backRatio': 0.20946628291434558, 'x': [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], 'y': [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], 'z': [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], 'mattype': ['a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457'], 'rearMat': ['a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310']},\n",
+       "    'Wm2Front': [896.0219999999999,\n",
+       "     895.7497333333332,\n",
+       "     895.4763999999999,\n",
+       "     899.9404666666666,\n",
+       "     899.9072,\n",
+       "     899.8732999999999,\n",
+       "     899.8394666666667,\n",
+       "     899.8056666666666],\n",
+       "    'Wm2Back': [148.30476666666667,\n",
+       "     110.41460000000001,\n",
+       "     103.01362666666667,\n",
+       "     108.25406666666667,\n",
+       "     131.30333333333334,\n",
+       "     172.55966666666666,\n",
+       "     229.1205666666667,\n",
+       "     310.21240000000006,\n",
+       "     380.3414],\n",
+       "    'backRatio': 0.20946628291434558}],\n",
+       "  'POA_eff': 1048.8622837592593,\n",
+       "  'Gfront_mean': 898.3267791666665,\n",
+       "  'Grear_mean': 188.16938074074076,\n",
+       "  'Pout_module': 379.6638001542193,\n",
+       "  'Mismatch': 0.06581846071414255,\n",
+       "  'Pout_module_reduced': 379.413911285069},\n",
+       " '2021-06-17_1400': {'surf_azm': 30.0,\n",
+       "  'surf_tilt': 10.0,\n",
+       "  'theta': 10.0,\n",
+       "  'ghi': 702,\n",
+       "  'dhi': 306,\n",
+       "  'temp_air': 27.8,\n",
+       "  'wind_speed': 5.1,\n",
+       "  'skyfile': 'skies\\\\sky2_39.742_-105.179_2021-06-17_1400.rad',\n",
+       "  'clearance_height': 0.2,\n",
+       "  'radfile': 'objects\\\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad',\n",
+       "  'scene': {'module': {'x': 1.59, 'y': 0.95, 'z': 0.02, 'modulematerial': 'black', 'scenex': 1.59, 'sceney': 0.95, 'scenez': 0.0, 'numpanels': 1, 'bifi': 0.8, 'text': '! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0', 'modulefile': 'objects\\\\test-module.rad', 'glass': False, 'offsetfromaxis': 0, 'xgap': 0.0, 'ygap': 0.0, 'zgap': 0.0}, 'modulefile': 'objects\\\\test-module.rad', 'hpc': False, 'gcr': 0.6333333333333333, 'text': '!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\\\test-module.rad', 'radfiles': 'objects\\\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad', 'sceneDict': {'tilt': 10.0, 'pitch': 1.5, 'clearance_height': 0.2, 'azimuth': 30.0, 'nMods': 10, 'nRows': 3, 'modulez': 0.02, 'axis_tilt': 0, 'originx': 0, 'originy': 0}},\n",
+       "  'octfile': '1axis_2021-06-17_1400.oct',\n",
+       "  'Results': [{'rowWanted': 2,\n",
+       "    'modWanted': 5,\n",
+       "    'AnalysisObj': {'octfile': '1axis_2021-06-17_1400.oct', 'name': '1axis_2021-06-17_1400', 'hpc': False, 'modWanted': 5, 'rowWanted': 2, 'Wm2Front': [643.2881000000001, 643.6341666666667, 643.9813666666665, 646.7371, 646.8992666666667, 647.0624666666668, 647.2256000000001, 649.5095666666666], 'Wm2Back': [119.69326666666667, 94.68362333333334, 86.35244999999999, 95.52069333333334, 117.2034, 149.02993333333333, 193.71370000000002, 243.32743333333335, 284.2796666666667], 'backRatio': 0.23799649547718552, 'x': [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], 'y': [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], 'z': [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], 'mattype': ['a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457'], 'rearMat': ['a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310']},\n",
+       "    'Wm2Front': [643.2881000000001,\n",
+       "     643.6341666666667,\n",
+       "     643.9813666666665,\n",
+       "     646.7371,\n",
+       "     646.8992666666667,\n",
+       "     647.0624666666668,\n",
+       "     647.2256000000001,\n",
+       "     649.5095666666666],\n",
+       "    'Wm2Back': [119.69326666666667,\n",
+       "     94.68362333333334,\n",
+       "     86.35244999999999,\n",
+       "     95.52069333333334,\n",
+       "     117.2034,\n",
+       "     149.02993333333333,\n",
+       "     193.71370000000002,\n",
+       "     243.32743333333335,\n",
+       "     284.2796666666667],\n",
+       "    'backRatio': 0.23799649547718552}],\n",
+       "  'POA_eff': 769.0470189814815,\n",
+       "  'Gfront_mean': 646.0422041666667,\n",
+       "  'Grear_mean': 153.75601851851854,\n",
+       "  'Pout_module': 286.41613980714925,\n",
+       "  'Mismatch': 0.1046380322450241,\n",
+       "  'Pout_module_reduced': 286.1164395944229}}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "demo2.trackerdict"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "dc349273",
    "metadata": {},
    "outputs": [],
@@ -214,10 +313,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "42c0c602",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'AnalysisObj'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[1;32m~\\AppData\\Local\\Temp\\1/ipykernel_2520/949070538.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mfrontirrad\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mtrackerdict\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mkeys\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m'AnalysisObj'\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mWm2Front\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mKeyError\u001b[0m: 'AnalysisObj'"
+     ]
+    }
+   ],
    "source": [
     "frontirrad = trackerdict[keys[0]]['AnalysisObj'].Wm2Front"
    ]

--- a/docs/tutorials/modelchain test.ipynb
+++ b/docs/tutorials/modelchain test.ipynb
@@ -121,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b9a7de53",
+   "id": "5b04c1c7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
      "text": [
       "\n",
       "New bifacial_radiance simulation starting. \n",
-      "Version:  0.4.1+15.gb7a948e.dirty\n",
+      "Version:  0.4.1+16.g0c78455.dirty\n",
       "path = C:\\Users\\sayala\\Documents\\GitHub\\bifacial_radiance\\bifacial_radiance\\TEMP\\Modelchain\n",
       "Loading times to restrict weather data to\n",
       "analysisParamsDict['modWanted'] set to middle module by default\n",
@@ -174,28 +174,16 @@
       "Linescan in process: 1axis_2021-06-17_1300_Row2_Module5_Back\n",
       "Saved: results\\irr_1axis_2021-06-17_1300_Row2_Module5_Front.csv\n",
       "Saved: results\\irr_1axis_2021-06-17_1300_Row2_Module5_Back.csv\n",
-      "Index: 2021-06-17_1300. Wm2Front: 898.4182666666667. Wm2Back: 188.6046951851852\n",
+      "Index: 2021-06-17_1300. Wm2Front: 897.6890375. Wm2Back: 188.0002166666667\n",
       "Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Front\n",
       "Linescan in process: 1axis_2021-06-17_1400_Row2_Module5_Back\n",
       "Saved: results\\irr_1axis_2021-06-17_1400_Row2_Module5_Front.csv\n",
       "Saved: results\\irr_1axis_2021-06-17_1400_Row2_Module5_Back.csv\n",
-      "Index: 2021-06-17_1400. Wm2Front: 646.4604708333333. Wm2Back: 153.67998259259258\n",
+      "Index: 2021-06-17_1400. Wm2Front: 646.1976916666667. Wm2Back: 152.18251999999998\n",
       "\n",
       "--> Calculating Performance values\n",
-      "Bifaciality factor of module stored is  0.8\n"
-     ]
-    },
-    {
-     "ename": "AttributeError",
-     "evalue": "'RadianceObj' object has no attribute 'cumulative'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[1;32m~\\AppData\\Local\\Temp\\1/ipykernel_10944/1998972661.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mdemo2\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0manalysis\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mbifacial_radiance\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodelchain\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mrunModelChain\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mParams\u001b[0m \u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32mc:\\users\\sayala\\documents\\github\\bifacial_radiance\\bifacial_radiance\\modelchain.py\u001b[0m in \u001b[0;36mrunModelChain\u001b[1;34m(simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellModuleDict, CECModParamsDict)\u001b[0m\n\u001b[0;32m    211\u001b[0m                 \u001b[0mmodfilter2\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mdb\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstr\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstartswith\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'Pr'\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m&\u001b[0m \u001b[0mdb\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstr\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mendswith\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'BHC72-400'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    212\u001b[0m                 \u001b[0mCECMod\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mdb\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mmodfilter2\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 213\u001b[1;33m             \u001b[0mdemo\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcalculateResults\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mCECMod\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mCECMod\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    214\u001b[0m             \u001b[0mdemo\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexportTrackerDict\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0msavefile\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mos\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'results'\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;34m'Final_Results.csv'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0mreindex\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mFalse\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    215\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mc:\\users\\sayala\\documents\\github\\bifacial_radiance\\bifacial_radiance\\main.py\u001b[0m in \u001b[0;36mcalculateResults\u001b[1;34m(self, CECMod, glassglass, bifacialityfactor, CECMod2)\u001b[0m\n\u001b[0;32m   2650\u001b[0m             \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Bifaciality factor of module stored is \"\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mbifacialityfactor\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   2651\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 2652\u001b[1;33m         \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcumulative\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   2653\u001b[0m             \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Add HERE gencusky1axis results for each tracekr angle\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   2654\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mAttributeError\u001b[0m: 'RadianceObj' object has no attribute 'cumulative'"
+      "Bifaciality factor of module stored is  0.8\n",
+      "Exporting TrackerDict\n"
      ]
     }
    ],
@@ -205,30 +193,125 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "1231f96a",
+   "execution_count": null,
+   "id": "1d1adb8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis -- Wm2Back adn Wm2Front\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "86970d4e",
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'demo2' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m~\\AppData\\Local\\Temp\\1/ipykernel_10944/1149153798.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mdemo2\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;31mNameError\u001b[0m: name 'demo2' is not defined"
-     ]
+     "data": {
+      "text/plain": [
+       "{'metdata': <bifacial_radiance.main.MetObj at 0x190eee00f10>,\n",
+       " 'data': {},\n",
+       " 'path': 'C:\\\\Users\\\\sayala\\\\Documents\\\\GitHub\\\\bifacial_radiance\\\\bifacial_radiance\\\\TEMP\\\\Modelchain',\n",
+       " 'name': '2021-06-17_1400',\n",
+       " 'materialfiles': ['materials\\\\ground.rad'],\n",
+       " 'skyfiles': ['skies\\\\sky2_39.742_-105.179_2021-06-17_1400.rad'],\n",
+       " 'radfiles': [],\n",
+       " 'octfile': '1axis_2021-06-17_1400.oct',\n",
+       " 'Wm2Front': 0,\n",
+       " 'Wm2Back': 0,\n",
+       " 'backRatio': 0,\n",
+       " 'nMods': 10,\n",
+       " 'nRows': 3,\n",
+       " 'hpc': False,\n",
+       " 'nowstr': '2022-03-11_1138',\n",
+       " 'basename': '_test_high_azimuth_angle_modelchain',\n",
+       " 'gencumsky_metfile': 'EPWs\\\\metdata_temp.csv',\n",
+       " 'ground': <bifacial_radiance.main.GroundObj at 0x190ec97ee50>,\n",
+       " 'module': {'x': 1.59, 'y': 0.95, 'z': 0.02, 'modulematerial': 'black', 'scenex': 1.59, 'sceney': 0.95, 'scenez': 0.0, 'numpanels': 1, 'bifi': 0.8, 'text': '! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0', 'modulefile': 'objects\\\\test-module.rad', 'glass': False, 'offsetfromaxis': 0, 'xgap': 0.0, 'ygap': 0.0, 'zgap': 0.0},\n",
+       " 'trackerdict': {'2021-06-17_1300': {'surf_azm': 30.0,\n",
+       "   'surf_tilt': 10.0,\n",
+       "   'theta': 10.0,\n",
+       "   'ghi': 959,\n",
+       "   'dhi': 172,\n",
+       "   'temp_air': 28.9,\n",
+       "   'wind_speed': 6.2,\n",
+       "   'skyfile': 'skies\\\\sky2_39.742_-105.179_2021-06-17_1300.rad',\n",
+       "   'clearance_height': 0.2,\n",
+       "   'radfile': 'objects\\\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad',\n",
+       "   'scene': {'module': {'x': 1.59, 'y': 0.95, 'z': 0.02, 'modulematerial': 'black', 'scenex': 1.59, 'sceney': 0.95, 'scenez': 0.0, 'numpanels': 1, 'bifi': 0.8, 'text': '! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0', 'modulefile': 'objects\\\\test-module.rad', 'glass': False, 'offsetfromaxis': 0, 'xgap': 0.0, 'ygap': 0.0, 'zgap': 0.0}, 'modulefile': 'objects\\\\test-module.rad', 'hpc': False, 'gcr': 0.6333333333333333, 'text': '!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\\\test-module.rad', 'radfiles': 'objects\\\\1axis2021-06-17_1300__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad', 'sceneDict': {'tilt': 10.0, 'pitch': 1.5, 'clearance_height': 0.2, 'azimuth': 30.0, 'nMods': 10, 'nRows': 3, 'modulez': 0.02, 'axis_tilt': 0, 'originx': 0, 'originy': 0}},\n",
+       "   'octfile': '1axis_2021-06-17_1300.oct',\n",
+       "   'Results': [{'rowWanted': 2,\n",
+       "     'modWanted': 5,\n",
+       "     'AnalysisObj': {'octfile': '1axis_2021-06-17_1300.oct', 'name': '1axis_2021-06-17_1300', 'hpc': False, 'modWanted': 5, 'rowWanted': 2, 'Wm2Front': [895.5053333333334, 895.7779, 896.0497333333333, 898.7332, 898.7845333333333, 898.8358666666667, 898.8872333333334, 898.9385000000001], 'Wm2Back': [146.7011, 111.57029999999999, 99.84521666666666, 109.47816666666667, 131.9399, 171.2386, 233.62636666666666, 308.50913333333335, 379.0931666666667], 'backRatio': 0.209426649303398, 'x': [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], 'y': [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], 'z': [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], 'mattype': ['a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457'], 'rearMat': ['a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310']},\n",
+       "     'Wm2Front': [895.5053333333334,\n",
+       "      895.7779,\n",
+       "      896.0497333333333,\n",
+       "      898.7332,\n",
+       "      898.7845333333333,\n",
+       "      898.8358666666667,\n",
+       "      898.8872333333334,\n",
+       "      898.9385000000001],\n",
+       "     'Wm2Back': [146.7011,\n",
+       "      111.57029999999999,\n",
+       "      99.84521666666666,\n",
+       "      109.47816666666667,\n",
+       "      131.9399,\n",
+       "      171.2386,\n",
+       "      233.62636666666666,\n",
+       "      308.50913333333335,\n",
+       "      379.0931666666667],\n",
+       "     'backRatio': 0.209426649303398}]},\n",
+       "  '2021-06-17_1400': {'surf_azm': 30.0,\n",
+       "   'surf_tilt': 10.0,\n",
+       "   'theta': 10.0,\n",
+       "   'ghi': 702,\n",
+       "   'dhi': 306,\n",
+       "   'temp_air': 27.8,\n",
+       "   'wind_speed': 5.1,\n",
+       "   'skyfile': 'skies\\\\sky2_39.742_-105.179_2021-06-17_1400.rad',\n",
+       "   'clearance_height': 0.2,\n",
+       "   'radfile': 'objects\\\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad',\n",
+       "   'scene': {'module': {'x': 1.59, 'y': 0.95, 'z': 0.02, 'modulematerial': 'black', 'scenex': 1.59, 'sceney': 0.95, 'scenez': 0.0, 'numpanels': 1, 'bifi': 0.8, 'text': '! genbox black test-module 1.59 0.95 0.02 | xform -t -0.795 -0.475 0 -a 1 -t 0 0.95 0', 'modulefile': 'objects\\\\test-module.rad', 'glass': False, 'offsetfromaxis': 0, 'xgap': 0.0, 'ygap': 0.0, 'zgap': 0.0}, 'modulefile': 'objects\\\\test-module.rad', 'hpc': False, 'gcr': 0.6333333333333333, 'text': '!xform -rx 10.0 -t 0 0 0.2824828843917919 -a 10 -t 1.59 0 0 -a 3 -t 0 1.5 0 -i 1 -t -6.36 -1.5 0 -rz 150.0 -t 0 0 0 objects\\\\test-module.rad', 'radfiles': 'objects\\\\1axis2021-06-17_1400__C_0.20000_rtr_1.50000_tilt_10.00000_10modsx3rows_origin0,0.rad', 'sceneDict': {'tilt': 10.0, 'pitch': 1.5, 'clearance_height': 0.2, 'azimuth': 30.0, 'nMods': 10, 'nRows': 3, 'modulez': 0.02, 'axis_tilt': 0, 'originx': 0, 'originy': 0}},\n",
+       "   'octfile': '1axis_2021-06-17_1400.oct',\n",
+       "   'Results': [{'rowWanted': 2,\n",
+       "     'modWanted': 5,\n",
+       "     'AnalysisObj': {'octfile': '1axis_2021-06-17_1400.oct', 'name': '1axis_2021-06-17_1400', 'hpc': False, 'modWanted': 5, 'rowWanted': 2, 'Wm2Front': [644.3194, 644.7297666666667, 645.1418333333332, 645.5538666666667, 645.9658666666666, 647.8394666666667, 647.9564333333333, 648.0749], 'Wm2Back': [117.00423333333333, 87.34127000000001, 87.59819333333333, 96.44088333333333, 114.32423333333334, 148.15723333333335, 192.7387, 242.80536666666663, 283.2325666666666], 'backRatio': 0.23550422178586114, 'x': [0.1870266, 0.1402483, 0.09346991, 0.04669154, -8.682409e-05, -0.04686519, -0.09364356, -0.1404219, -0.1872003], 'y': [0.3239397, 0.2429171, 0.1618946, 0.08087213, -0.0001503837, -0.08117289, -0.1621954, -0.2432179, -0.3242404], 'z': [0.2155118, 0.2320083, 0.2485049, 0.2650015, 0.2814981, 0.2979947, 0.3144912, 0.3309878, 0.3474844], 'mattype': ['a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457', 'a4.1.a0.test-module.6457'], 'rearMat': ['a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310', 'a4.1.a0.test-module.2310']},\n",
+       "     'Wm2Front': [644.3194,\n",
+       "      644.7297666666667,\n",
+       "      645.1418333333332,\n",
+       "      645.5538666666667,\n",
+       "      645.9658666666666,\n",
+       "      647.8394666666667,\n",
+       "      647.9564333333333,\n",
+       "      648.0749],\n",
+       "     'Wm2Back': [117.00423333333333,\n",
+       "      87.34127000000001,\n",
+       "      87.59819333333333,\n",
+       "      96.44088333333333,\n",
+       "      114.32423333333334,\n",
+       "      148.15723333333335,\n",
+       "      192.7387,\n",
+       "      242.80536666666663,\n",
+       "      283.2325666666666],\n",
+       "     'backRatio': 0.23550422178586114}]}},\n",
+       " 'cumulativesky': False,\n",
+       " 'hub_height': 0.2}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "demo2"
+    "demo2.__dict__"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "886947cb",
+   "id": "39a94675",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a19e411",
+   "id": "7537ae81",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/tutorials/modelchain test.py
+++ b/docs/tutorials/modelchain test.py
@@ -40,32 +40,50 @@ Params[0]['weatherFile'] = weatherfile
 Params[2].update({'starttime': '06_17_13', 'endtime':'06_17_14'}); 
 
 
-# In[15]:
+# In[6]:
 
 
 Params[6]['modWanted'] = [1, 3]
 
 
-# In[16]:
+# In[7]:
 
 
 demo2, analysis = bifacial_radiance.modelchain.runModelChain(*Params ) 
 
 
-# In[8]:
-
-
-demo2.trackerdict
-
-
 # In[9]:
+
+
+demo2
+
+
+# In[ ]:
+
+
+demo2
+
+
+# In[ ]:
+
+
+demo2
+
+
+# In[ ]:
+
+
+demo2.results
+
+
+# In[ ]:
 
 
 trackerdict = demo2.trackerdict
 keys = list(demo2.trackerdict.keys())
 
 
-# In[10]:
+# In[ ]:
 
 
 frontirrad = trackerdict[keys[0]]['AnalysisObj'].Wm2Front

--- a/docs/tutorials/modelchain test.py
+++ b/docs/tutorials/modelchain test.py
@@ -52,10 +52,16 @@ Params[6]['modWanted'] = [1, 3]
 demo2, analysis = bifacial_radiance.modelchain.runModelChain(*Params ) 
 
 
-# In[9]:
+# In[ ]:
 
 
-demo2
+analysis -- Wm2Back adn Wm2Front
+
+
+# In[13]:
+
+
+demo2.__dict__
 
 
 # In[ ]:

--- a/docs/tutorials/modelchain test.py
+++ b/docs/tutorials/modelchain test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-# In[2]:
+# In[1]:
 
 
 import bifacial_radiance
@@ -9,7 +9,7 @@ import os
 import pandas as pd
 
 
-# In[3]:
+# In[2]:
 
 
 inifile = r'C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\ini_highAzimuth.ini'
@@ -20,19 +20,19 @@ weatherfile = r'C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\724666T
 testfolder = r'C:\Users\sayala\Documents\GitHub\bifacial_radiance\bifacial_radiance\TEMP\Modelchain'
 
 
-# In[4]:
+# In[3]:
 
 
 (Params)= bifacial_radiance.load.readconfigurationinputfile(inifile=inifile)
 
 
-# In[5]:
+# In[4]:
 
 
 Params
 
 
-# In[6]:
+# In[5]:
 
 
 Params[0]['testfolder'] = testfolder
@@ -40,26 +40,32 @@ Params[0]['weatherFile'] = weatherfile
 Params[2].update({'starttime': '06_17_13', 'endtime':'06_17_14'}); 
 
 
-# In[7]:
+# In[15]:
+
+
+Params[6]['modWanted'] = [1, 3]
+
+
+# In[16]:
 
 
 demo2, analysis = bifacial_radiance.modelchain.runModelChain(*Params ) 
 
 
-# In[ ]:
+# In[8]:
 
 
 demo2.trackerdict
 
 
-# In[ ]:
+# In[9]:
 
 
 trackerdict = demo2.trackerdict
 keys = list(demo2.trackerdict.keys())
 
 
-# In[ ]:
+# In[10]:
 
 
 frontirrad = trackerdict[keys[0]]['AnalysisObj'].Wm2Front

--- a/docs/tutorials/modelchain test.py
+++ b/docs/tutorials/modelchain test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-# In[1]:
+# In[2]:
 
 
 import bifacial_radiance
@@ -9,33 +9,30 @@ import os
 import pandas as pd
 
 
-# In[19]:
+# In[3]:
 
 
 inifile = r'C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\ini_highAzimuth.ini'
+#inifile = r'C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\ini_gencumsky.ini'
+#inifile = r'C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\ini_1axis.ini'
+
 weatherfile = r'C:\Users\sayala\Documents\GitHub\bifacial_radiance\tests\724666TYA.csv'
 testfolder = r'C:\Users\sayala\Documents\GitHub\bifacial_radiance\bifacial_radiance\TEMP\Modelchain'
 
 
-# In[14]:
+# In[4]:
 
 
 (Params)= bifacial_radiance.load.readconfigurationinputfile(inifile=inifile)
 
 
-# In[15]:
+# In[5]:
 
 
-Params[0]
+Params
 
 
-# In[16]:
-
-
-Params[2]
-
-
-# In[24]:
+# In[6]:
 
 
 Params[0]['testfolder'] = testfolder
@@ -43,19 +40,38 @@ Params[0]['weatherFile'] = weatherfile
 Params[2].update({'starttime': '06_17_13', 'endtime':'06_17_14'}); 
 
 
-# In[25]:
+# In[7]:
 
 
 demo2, analysis = bifacial_radiance.modelchain.runModelChain(*Params ) 
 
 
-# In[37]:
+# In[ ]:
 
 
 demo2.trackerdict
 
 
-# In[39]:
+# In[ ]:
+
+
+trackerdict = demo2.trackerdict
+keys = list(demo2.trackerdict.keys())
+
+
+# In[ ]:
+
+
+frontirrad = trackerdict[keys[0]]['AnalysisObj'].Wm2Front
+
+
+# In[ ]:
+
+
+type(frontirrad)
+
+
+# In[ ]:
 
 
 #CEC Module
@@ -66,23 +82,89 @@ CECMod = db[modfilter2]
 print(len(CECMod), " modules selected. Name of 1st entry: ", CECMod.index[0])
 
 
-# In[47]:
+# In[ ]:
 
 
-trackerdict = demo2.calculatePerformanceModule(CECMod)
-
-
-# In[46]:
-
-
-demo2.exportTrackerDict(savefile=os.path.join('results','Final_Results.csv'),reindex=False)
-pd.read_csv(os.path.join('results','Final_Results.csv'))
+type(CECMod)
 
 
 # In[ ]:
 
 
-#assert np.round(np.mean(analysis.backRatio),2) == 0.20  # bifi ratio was == 0.22 in v0.2.2
-assert np.mean(analysis.Wm2Front) == pytest.approx(898, rel = 0.005)  # was 912 in v0.2.3
-assert np.mean(analysis.Wm2Back) == pytest.approx(189, rel = 0.02)  # was 182 in v0.2.2
+CECModParamsDict = Params[-1]
+
+
+# In[ ]:
+
+
+CECModParamsDict
+
+
+# In[ ]:
+
+
+pd.DataFrame(CECModParamsDict, index=[0])
+
+
+# In[ ]:
+
+
+import numpy as np
+
+
+# In[ ]:
+
+
+demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[1] = np.nan
+demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[2] = np.nan
+demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[3] = np.nan
+demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[4] = np.nan
+demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[5] = np.nan
+demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[6] = np.nan
+demo2.trackerdict[keys[0]]['AnalysisObj'].Wm2Front[7] = np.nan
+
+
+# In[ ]:
+
+
+type(CECMod)
+
+
+# In[ ]:
+
+
+CECMod)
+
+
+# In[ ]:
+
+
+trackerdict = demo2.calculateResults(CECMod = CECMod)
+
+
+# In[ ]:
+
+
+CECMod.Adjust
+
+
+# In[ ]:
+
+
+print("Error: Mising/wrong parameters for CECMod, setting dictionary to None.",
+      "MAke sure to include alpha_sc, a_ref, I_L_ref, I_o_ref, ",
+      "R_sh_ref, R_s, and Adjust"
+      "Performance calculations, if performed, will use default module")
+
+
+# In[ ]:
+
+
+demo2.exportTrackerDict(savefile=os.path.join('results','Final_Results.csv'),reindex=False)
+
+
+# In[ ]:
+
+
+pd.read_csv(os.path.join('results','Final_Results.csv'))
 

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -169,7 +169,7 @@ def test_RadianceObj_1axis_gendaylit_end_to_end():
     #demo.makeScene1axis({key:trackerdict[key]}, module_type,sceneDict, cumulativesky = False, nMods = 10, nRows = 3, modwanted = 7, rowwanted = 3, sensorsy = 2) #makeScene creates a .rad file with 20 modules per row, 7 rows.
     
     demo.makeOct1axis(trackerdict,key) # just run this for one timestep: Jan 1 11am
-    trackerdict = demo.analysis1axis(trackerdict, singleindex=key, modWanted=7, rowWanted=3, sensorsy=2) # just run this for one timestep: Jan 1 11am
+    trackerdict = demo.analysis1axis(trackerdict, singleindex=key, modWanted=[6,7], rowWanted=3, sensorsy=2) # just run this for one timestep: Jan 1 11am
     
     #V 0.2.5 fixed the gcr passed to set1axis. (since gcr was not being passd to set1axis, gcr was default 0.33 default). 
     assert(np.mean(demo.Wm2Front) == pytest.approx(205.0, 0.01) ) # was 214 in v0.2.3  # was 205 in early v0.2.4  

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -137,8 +137,8 @@ def test_Radiance_1axis_gendaylit_modelchains():
     # unpack the Params tuple with *Params
     demo2, analysis = bifacial_radiance.modelchain.runModelChain(*Params) 
     #V 0.2.5 fixed the gcr passed to set1axis. (since gcr was not being passd to set1axis, gcr was default 0.33 default). 
-    assert(np.mean(demo2.Wm2Front) == pytest.approx(205.0, 0.01) ) # was 214 in v0.2.3  # was 205 in early v0.2.4  
-    assert(np.mean(demo2.Wm2Back) == pytest.approx(43.0, 0.1) )
+    assert(demo2.CompiledResults.Gfront_mean[0] == pytest.approx(205.0, 0.01) ) # was 214 in v0.2.3  # was 205 in early v0.2.4  
+    assert(demo2.CompiledResults.Grear_mean[0] == pytest.approx(43.0, 0.1) )
     assert demo2.trackerdict['2001-01-01_1100']['scene'].text.__len__() == 132
     assert demo2.trackerdict['2001-01-01_1100']['scene'].text[23:28] == " 2.0 "
     demo2.exportTrackerDict(savefile = 'results\exportedTrackerDict.csv', reindex=True)
@@ -171,10 +171,11 @@ def test_RadianceObj_1axis_gendaylit_end_to_end():
     
     demo.makeOct1axis(trackerdict,key) # just run this for one timestep: Jan 1 11am
     trackerdict = demo.analysis1axis(trackerdict, singleindex=key, modWanted=[6,7], rowWanted=3, sensorsy=2) # just run this for one timestep: Jan 1 11am
-    
+    trackerdict = demo.calculateResults()
+    demo.exportTrackerDict(savefile=os.path.join('results','Final_Results.csv'),reindex=False)
     #V 0.2.5 fixed the gcr passed to set1axis. (since gcr was not being passd to set1axis, gcr was default 0.33 default). 
-    assert(np.mean(demo.Wm2Front) == pytest.approx(205.0, 0.01) ) # was 214 in v0.2.3  # was 205 in early v0.2.4  
-    assert(np.mean(demo.Wm2Back) == pytest.approx(43.0, 0.1) )
+    assert(demo.CompiledResults.Gfront_mean == pytest.approx(205.0, 0.01) ) # was 214 in v0.2.3  # was 205 in early v0.2.4  
+    assert(demo.CompiledResults.Grear_mean == pytest.approx(43.0, 0.1) )
 """
 
 def test_1axis_gencumSky():

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -163,7 +163,7 @@ def test_RadianceObj_1axis_gendaylit_end_to_end():
     # create metdata files for each condition. keys are timestamps for gendaylit workflow
     trackerdict = demo.set1axis(cumulativesky=False, gcr=gcr)
     # create the skyfiles needed for 1-axis tracking
-    demo.gendaylit1axis(metdata=metdata, enddate='01/01')
+    demo.gendaylit1axis(metdata=metdata)
     # Create the scene for the 1-axis tracking
     demo.makeScene1axis({key:trackerdict[key]}, module='test-module', sceneDict=sceneDict, cumulativesky = False)
     #demo.makeScene1axis({key:trackerdict[key]}, module_type,sceneDict, cumulativesky = False, nMods = 10, nRows = 3, modwanted = 7, rowwanted = 3, sensorsy = 2) #makeScene creates a .rad file with 20 modules per row, 7 rows.

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -133,6 +133,7 @@ def test_Radiance_1axis_gendaylit_modelchains():
 
     (Params)= bifacial_radiance.load.readconfigurationinputfile(inifile=filename)
     Params[0]['testfolder'] = TESTDIR
+    Params[6]['modWanted'] = [6,7]
     # unpack the Params tuple with *Params
     demo2, analysis = bifacial_radiance.modelchain.runModelChain(*Params) 
     #V 0.2.5 fixed the gcr passed to set1axis. (since gcr was not being passd to set1axis, gcr was default 0.33 default). 

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -219,11 +219,11 @@ def test_1axis_gencumSky():
     minitrackerdict[list(trackerdict)[0]] = trackerdict[list(trackerdict.keys())[0]]
     trackerdict = demo.makeOct1axis(trackerdict=minitrackerdict) # just run this for one timestep: Jan 1 11am
     trackerdict = demo.analysis1axis(trackerdict=trackerdict, modWanted=7, rowWanted=3, sensorsy=2) 
-    assert trackerdict[-5.0]['AnalysisObj'].x[0] == -10.76304
+    assert trackerdict[-5.0]['Results'][0]['AnalysisObj'].x[0] == -10.76304
     modscanfront = {}
     modscanfront = {'xstart': -5}
     trackerdict = demo.analysis1axis(trackerdict=trackerdict, modWanted=7, rowWanted=3, sensorsy=2, modscanfront=modscanfront ) 
-    assert trackerdict[-5.0]['AnalysisObj'].x[0] == -5
+    assert trackerdict[-5.0]['Results'][0]['AnalysisObj'].x[0] == -5
 
 
 


### PR DESCRIPTION
Fixes #405.

- [ ] Pytests
- [ ] Docstrings
- [ ] Tutorials updated
- [x] whatsnew

This updates the trackerdict by having multiple AnalysisObjects in it rather than just one.  However, there are some semi-major changes required.
1. All results .csv files being created in the /Results/ folder now have a _RowX_ModuleY_ in the filename by default.  That way you can track down what module and row the given result is coming from.  This was already being done with analyzeRow, but now it's done with every file generated with moduleAnalysis.
2. It's not just the AnalysisObj that is changing if you have multiple modules, your Wm2Front and Wm2Back and backRatio is changing too.  So all of those things are now shifted to a 'Results' array of dictionaries.  It's kind of klunky - instead of trackerdict[index]['AnalysisObj'] it's in  trackerdict[index]['Results'][XXX]['AnalysisObj']  (where XXX is the number of the row/module list, 0 by default)
3. Both the modWanted and rowWanted value is being saved in 'Results' as well as in the AnalysisObj
4. If you pass an array for both modWanted and rowWanted, it runs simulation for all permutations, for a total of N x M simulations.
5. Cumulative values stored in demo.Wm2Front is only for the LAST module/row pair.