### PR TITLE
390 module text manual inputs

### DIFF
--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -55,7 +55,8 @@ class ModuleObj(SuperClass):
         modulefile : str
             Existing radfile location in \objects.  Otherwise a default value is used
         text : str
-            Text used in the radfile to generate the module
+            Text used in the radfile to generate the module. Manually passing
+            this value will overwrite module definition
         customtext : str
             Added-text used in the radfile to generate any
             extra details in the racking/module. Does not overwrite
@@ -106,7 +107,7 @@ class ModuleObj(SuperClass):
         self.customtext = customtext
         
         # are we writing to JSON with passed data or just reading existing?
-        if (x is None) & (y is None) & (cellModule is None):
+        if (x is None) & (y is None) & (cellModule is None) & (text is None):
             #just read in file. If .rad file doesn't exist, make it.
             self.readModule(name=name)
             if name is not None:
@@ -153,11 +154,16 @@ class ModuleObj(SuperClass):
                 self.modulefile = os.path.join('objects',
                                                        self.name + '.rad')
                 print("\nModule Name:", self.name)
-                  
-            if hpc:
-                self.compileText(rewriteModulefile, json=False)
+            if text is not None:
+                print('Warning: Module text manually passed and will not be '
+                      f'saved: {text}')
+                self._saveModule(savedata=self.getDataDict(),
+                                 rewriteModulefile=rewriteModulefile)
             else:
-                self.compileText(rewriteModulefile)
+                if hpc:
+                    self.compileText(rewriteModulefile, json=False)
+                else:
+                    self.compileText(rewriteModulefile)
             
     def compileText(self, rewriteModulefile=True, json=True):
         """

--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -154,16 +154,11 @@ class ModuleObj(SuperClass):
                 self.modulefile = os.path.join('objects',
                                                        self.name + '.rad')
                 print("\nModule Name:", self.name)
-            if text is not None:
-                print('Warning: Module text manually passed and not '
-                      f'generated: {text}')
-                self._saveModule(savedata=self.getDataDict(),
-                                 rewriteModulefile=rewriteModulefile)
+
+            if hpc:
+                self.compileText(rewriteModulefile, json=False)
             else:
-                if hpc:
-                    self.compileText(rewriteModulefile, json=False)
-                else:
-                    self.compileText(rewriteModulefile)
+                self.compileText(rewriteModulefile)
             
     def compileText(self, rewriteModulefile=True, json=True):
         """
@@ -510,23 +505,30 @@ class ModuleObj(SuperClass):
             modulematerial = 'black'
             self.modulematerial = 'black'
             
-        if hasattr(self, 'cellModule'):
-            (text, x, y, _cc) = self.cellModule._makeCellLevelModule(self, z, Ny, ygap, 
-                                   modulematerial) 
-        else:
-            try:
-                text = '! genbox {} {} {} {} {} '.format(modulematerial, 
-                                                          self.name, x, y, z)
-                text +='| xform -t {} {} {} '.format(-x/2.0,
-                                        (-y*Ny/2.0)-(ygap*(Ny-1)/2.0),
-                                        self.offsetfromaxis)
-                text += '-a {} -t 0 {} 0'.format(Ny, y+ygap)
-                packagingfactor = 100.0
+        if self.text is not None:
+            text = self.text
+            print('Warning: Module text manually passed and not '
+                  f'generated: {text}')
 
-            except Exception as err: # probably because no x or y passed
-                raise Exception('makeModule variable {}'.format(err.args[0])+
-                                ' and cellModule is None.  '+
-                                'One or the other must be specified.')
+        else:
+            
+            if hasattr(self, 'cellModule'):
+                (text, x, y, _cc) = self.cellModule._makeCellLevelModule(self, z, Ny, ygap, 
+                                       modulematerial) 
+            else:
+                try:
+                    text = '! genbox {} {} {} {} {} '.format(modulematerial, 
+                                                              self.name, x, y, z)
+                    text +='| xform -t {} {} {} '.format(-x/2.0,
+                                            (-y*Ny/2.0)-(ygap*(Ny-1)/2.0),
+                                            self.offsetfromaxis)
+                    text += '-a {} -t 0 {} 0'.format(Ny, y+ygap)
+                    packagingfactor = 100.0
+    
+                except Exception as err: # probably because no x or y passed
+                    raise Exception('makeModule variable {}'.format(err.args[0])+
+                                    ' and cellModule is None.  '+
+                                    'One or the other must be specified.')
  
             
         self.scenex = x + xgap

--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -155,8 +155,8 @@ class ModuleObj(SuperClass):
                                                        self.name + '.rad')
                 print("\nModule Name:", self.name)
             if text is not None:
-                print('Warning: Module text manually passed and will not be '
-                      f'saved: {text}')
+                print('Warning: Module text manually passed and not '
+                      f'generated: {text}')
                 self._saveModule(savedata=self.getDataDict(),
                                  rewriteModulefile=rewriteModulefile)
             else:

--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -160,7 +160,7 @@ class ModuleObj(SuperClass):
                 self.modulefile = os.path.join('objects',
                                                        self.name + '.rad')
                 print("\nModule Name:", self.name)
-
+                  
             if hpc:
                 self.compileText(rewriteModulefile, json=False)
             else:

--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -105,6 +105,7 @@ class ModuleObj(SuperClass):
         # TODO: Address above comment?        
         self.name = str(name).strip().replace(' ', '_') 
         self.customtext = customtext
+        self._manual_text = text
         
         # are we writing to JSON with passed data or just reading existing?
         if (x is None) & (y is None) & (cellModule is None) & (text is None):
@@ -145,6 +146,11 @@ class ModuleObj(SuperClass):
                 
             if cellModule:
                 self.addCellModule(**cellModule, recompile=False)
+            
+            if self._manual_text:
+                print('Warning: Module text manually passed and not '
+                      f'generated: {self._manual_text}')
+            
             
             # set data object attributes from datakey list. 
             for key in self.keys:
@@ -505,10 +511,9 @@ class ModuleObj(SuperClass):
             modulematerial = 'black'
             self.modulematerial = 'black'
             
-        if self.text is not None:
-            text = self.text
-            print('Warning: Module text manually passed and not '
-                  f'generated: {text}')
+        if self._manual_text is not None:
+            text = self._manual_text
+            self._manual_text = None
 
         else:
             

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -186,7 +186,9 @@ def test_1axis_gencumSky():
     demo = bifacial_radiance.RadianceObj(name)  # Create a RadianceObj 'object'
     demo.setGround(albedo) # input albedo number or material name like 'concrete'.  To see options, run this without any input.
     metdata = demo.readWeatherFile(weatherFile=MET_FILENAME, starttime='01_01_01', endtime = '01_01_23', coerce_year=2001) # read in the EPW weather data from above
-    module=demo.makeModule(name='test-module',x=0.984,y=1.95, numpanels = 2, ygap = 0.1)
+    moduleText = '! genbox black test-module 0.98 1.95 0.02 | xform -t -0.49 -2.0 0 -a 2 -t 0 2.05 0'
+    module=demo.makeModule(name='test-module',x=0.984,y=1.95, numpanels = 2, ygap = 0.1, text=moduleText)
+    assert module.text == moduleText
     pitch= np.round(module.sceney / gcr,3)
     trackerdict = demo.set1axis(cumulativesky = True, gcr=gcr)
     demo.genCumSky1axis()

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -50,12 +50,12 @@ def test_CellLevelModule():
     name = "_test_CellLevelModule"
     demo = bifacial_radiance.RadianceObj(name)  # Create a RadianceObj 'object'
 
-    module = demo.makeModule(name='test-module', rewriteModulefile=True, cellModule=cellParams)
+    module = demo.makeModule(name='test-module', rewriteModulefile=True, cellModule=cellParams, customtext=' | xform -t 0 0.181 0')
     assert module.x == 1.036
     assert module.y == 1.74
     assert module.scenex == 1.046
     assert module.sceney == 1.74
-    assert module.text == '! genbox black cellPVmodule 0.156 0.156 0.02 | xform -t -0.44 -0.87 0 -a 6 -t 0.176 0 0 -a 10 -t 0 0.176 0 -a 1 -t 0 1.74 0'
+    assert module.text == '! genbox black cellPVmodule 0.156 0.156 0.02 | xform -t -0.44 -0.87 0 -a 6 -t 0.176 0 0 -a 10 -t 0 0.176 0 -a 1 -t 0 1.74 0 | xform -t 0 0.181 0'
 
     module.addCellModule(**cellParams, centerJB=0.01)  #centerJB simulations still under development.
 #    assert module.text == '! genbox black cellPVmodule 0.156 0.156 0.02 | xform -t -0.44 -0.87 0 -a 6 -t 0.176 0 0 -a 5.0 -t 0 0.176 0 -a 2 -t 0 0.772 0 | xform -t 0 0.181 0 -a 1 -t 0 1.73 0'


### PR DESCRIPTION
This will allow the module text to be manually input into makeModule and ModuleObj.  This should return functionality that used to exist previous to 0.4.0.  Importantly, there are now pytests for manually passing 'text' into ModuleObj to ensure this functionality remains.