### PR TITLE
421 save image

### DIFF
--- a/bifacial_radiance/gui.py
+++ b/bifacial_radiance/gui.py
@@ -287,7 +287,8 @@ class Window(tk.Tk):
             if selectTimes is not None: simulationParamsDict['selectTimes'] =  selectTimes            
             if lat is not None: simulationParamsDict['latitude'] = lat
             if lon is not None: simulationParamsDict['longitude'] = lon
-
+            simulationParamsDict['saveImage'] =  True 
+            
             if entry_starttime is not None: timeControlParamsDict['starttime'] =  starttime
             if entry_endtime is not None: timeControlParamsDict['endtime'] =  endtime
         

--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -3034,7 +3034,8 @@ class SceneObj:
 
     def saveImage(self, filename=None, view=None):
         """
-        Duplicate objview process to save an image of the scene to /images/
+        Save an image of the scene to /images/.    A default ground (concrete material) 
+        and sun (due East or West azimuth and 65 elevation) are created. 
 
         Parameters:    
             filename : string, optional. name for image file, defaults to scene name

--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -352,8 +352,8 @@ class RadianceObj:
         self.Wm2Front = 0       # cumulative tabulation of front W/m2
         self.Wm2Back = 0        # cumulative tabulation of rear W/m2
         self.backRatio = 0      # ratio of rear / front Wm2
-        self.nMods = None        # number of modules per row
-        self.nRows = None        # number of rows per scene
+        #self.nMods = None        # number of modules per row
+        #self.nRows = None        # number of rows per scene
         self.hpc = hpc           # HPC simulation is being run. Some read/write functions are modified
         
         now = datetime.datetime.now()
@@ -2135,9 +2135,9 @@ class RadianceObj:
                                                                 preferred='clearance_height', 
                                                                 nonpreferred='hub_height')
         
-        self.nMods = sceneDict['nMods']
-        self.nRows = sceneDict['nRows']
-        self.sceneRAD = self.scene._makeSceneNxR(sceneDict=sceneDict,
+        #self.nMods = sceneDict['nMods']
+        #self.nRows = sceneDict['nRows']
+        sceneRAD = self.scene._makeSceneNxR(sceneDict=sceneDict,
                                                  radname=radname)
 
         if 'appendRadfile' not in sceneDict:
@@ -2148,18 +2148,18 @@ class RadianceObj:
         if appendRadfile:
             debug = False
             try:
-                self.radfiles.append(self.sceneRAD)
+                self.radfiles.append(sceneRAD)
                 if debug:
                     print( "Radfile APPENDED!")
             except:
                 #TODO: Manage situation where radfile was created with
                 #appendRadfile to False first..
                 self.radfiles=[]
-                self.radfiles.append(self.sceneRAD)
+                self.radfiles.append(sceneRAD)
                 if debug:
                     print( "Radfile APPENDAGE created!")
         else:
-            self.radfiles = [self.sceneRAD]
+            self.radfiles = [sceneRAD]
         return self.scene
 
     def appendtoScene(self, radfile=None, customObject=None, text=''):
@@ -2313,12 +2313,12 @@ class RadianceObj:
                         * scene.module.sceney + scene.module.offsetfromaxis \
                         * math.sin(abs(theta)*math.pi/180)
                 # Calculate the ground clearance height based on the hub height. Add abs(theta) to avoid negative tilt angle errors
-                trackerdict[theta]['clearance_height'] = height
+                #trackerdict[theta]['clearance_height'] = height
 
                 try:
                     sceneDict2 = {'tilt':trackerdict[theta]['surf_tilt'],
                                   'pitch':sceneDict['pitch'],
-                                  'clearance_height':trackerdict[theta]['clearance_height'],
+                                  'clearance_height':height,
                                   'azimuth':trackerdict[theta]['surf_azm'],
                                   'nMods': sceneDict['nMods'],
                                   'nRows': sceneDict['nRows'],
@@ -2327,7 +2327,7 @@ class RadianceObj:
                     #maybe gcr is passed, not pitch
                     sceneDict2 = {'tilt':trackerdict[theta]['surf_tilt'],
                                   'gcr':sceneDict['gcr'],
-                                  'clearance_height':trackerdict[theta]['clearance_height'],
+                                  'clearance_height':height,
                                   'azimuth':trackerdict[theta]['surf_azm'],
                                   'nMods': sceneDict['nMods'],
                                   'nRows': sceneDict['nRows'],
@@ -2358,11 +2358,11 @@ class RadianceObj:
                         * math.sin(abs(theta)*math.pi/180)
 
                 if trackerdict[time]['ghi'] > 0:
-                    trackerdict[time]['clearance_height'] = height
+                    #trackerdict[time]['clearance_height'] = height
                     try:
                         sceneDict2 = {'tilt':trackerdict[time]['surf_tilt'],
                                       'pitch':sceneDict['pitch'],
-                                      'clearance_height': trackerdict[time]['clearance_height'],
+                                      'clearance_height': height,
                                       'azimuth':trackerdict[time]['surf_azm'],
                                       'nMods': sceneDict['nMods'],
                                       'nRows': sceneDict['nRows'],
@@ -2371,7 +2371,7 @@ class RadianceObj:
                         #maybe gcr is passed instead of pitch
                         sceneDict2 = {'tilt':trackerdict[time]['surf_tilt'],
                                       'gcr':sceneDict['gcr'],
-                                      'clearance_height': trackerdict[time]['clearance_height'],
+                                      'clearance_height': height,
                                       'azimuth':trackerdict[time]['surf_azm'],
                                       'nMods': sceneDict['nMods'],
                                       'nRows': sceneDict['nRows'],
@@ -2478,9 +2478,9 @@ class RadianceObj:
             trackerkeys = [singleindex]
 
         if modWanted == None:
-            modWanted = round(self.nMods / 1.99)
+            modWanted = round(self.scene.sceneDict['nMods'] / 1.99)
         if rowWanted == None:
-            rowWanted = round(self.nRows / 1.99)
+            rowWanted = round(self.scene.sceneDict['nRows'] / 1.99)
 
        
         frontWm2 = 0 # container for tracking front irradiance across module chord. Dynamically size based on first analysis run
@@ -2804,10 +2804,22 @@ class SceneObj:
     x = 0 vertical centerline of module
 
     scene includes module details (x,y,bifi, sceney (collector_width), scenex)
+    
+    Parameters
+    ------------
+    module : str or ModuleObj
+            String name of module created with makeModule()
+    name : str
+           Identifier of scene in case of multiple scenes. Default `Scene0'.
+           Automatically increments if makeScene is run multiple times.
+
+    Returns
+    -------
+    
     '''
     def __repr__(self):
         return str(self.__dict__)
-    def __init__(self, module=None):
+    def __init__(self, module=None, name=None):
         ''' initialize SceneObj
         '''
         from bifacial_radiance import ModuleObj
@@ -2829,7 +2841,10 @@ class SceneObj:
         
         self.modulefile = self.module.modulefile
         self.hpc = False  #default False.  Set True by makeScene after sceneobj created.
-
+        if name is None:
+            self.name = 'Scene0'
+        else:
+            self.name = name
 
     def _makeSceneNxR(self, modulename=None, sceneDict=None, radname=None):
         """
@@ -3845,19 +3860,6 @@ class AnalysisObj:
                 df['rearR'] = reardata['r']
                 df['rearG'] = reardata['g']
                 df['rearB'] = reardata['b']
-                #df = df[['x','y','z','rearZ','mattype','rearMat',
-                #                    'Wm2Front','Wm2Back','Back/FrontRatio',
-                #                    'r','g','b', 'rearR','rearG','rearB']]
-            #else:
-                #df = df[['x','y','z','rearZ','mattype','rearMat',
-                #                     'Wm2Front','Wm2Back','Back/FrontRatio']]
-
-        #else:
-        #    if RGB:
-        #        df = df[['x','y','z', 'mattype','Wm2Front', 'r', 'g', 'b']]
-        #
-        #    else:
-        #        df = df[['x','y','z', 'mattype','Wm2Front']]
                 
         # rename columns if only rear data was originally passed
         if rearswapflag:
@@ -4412,8 +4414,6 @@ def quickExample(testfolder=None):
             title = 'Select or create an empty directory for the Radiance tree')
 
     demo = bifacial_radiance.RadianceObj('simple_panel', path=testfolder)  # Create a RadianceObj 'object'
-
-    #    A=load_inputvariablesfile()
 
     # input albedo number or material name like 'concrete'.
     # To see options, run setGround without any input.

--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -3059,7 +3059,6 @@ class SceneObj:
                         f"{self.radfiles} {ltfile}\n".replace("\\",'/') +\
                     f"EXPOSURE= .5\nUP= Z\nview= {view.replace('.vp','')} -vf views/{view}\n" +\
                     f"oconv= -f\nPICT= images/{filename}")
-        print('')
         _,err = _popen(["rad",'-s',riffile], None)
         if err:
             print(err)

--- a/bifacial_radiance/modelchain.py
+++ b/bifacial_radiance/modelchain.py
@@ -195,28 +195,31 @@ def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=N
         analysis = demo.trackerdict[list(demo.trackerdict.keys())[-1]]['AnalysisObj']
         
     # Save example image files
-    if simulationParamsDict.get('makeImage'):
+    #print(simulationParamsDict)
+    if simulationParamsDict.get('saveImage'):
         if hasattr(demo, 'trackerdict'):
-            (bestkey, viewfile) = _getDesiredIndex(demo.trackerdict)
+            bestkey = _getDesiredIndex(demo.trackerdict)
             scene = demo.trackerdict[bestkey]['scene']
+            imagefilename = f'scene_{bestkey}'
+            viewfile = None # just use default value for now. Improve later..
         elif hasattr(demo, 'scene'):
             scene = demo.scene
-            viewfile = 'side.vp'
+            viewfile = None # just use default value for now. Improve later..
+            imagefilename = 'scene0'
         try:
-            print("Saving images")
-            scene.saveImage(viewfile)
+            print("\nSaving scene and module .hdr to images/")
+            scene.saveImage(filename=imagefilename, view=viewfile)
             #analysis.makeFalseColor('side.vp')
-            module.saveImage()
+            scene.module.saveImage()
         except:
             print("Failed to make image")        
 
-    
+    print("Finished! ")
     return demo, analysis
 
 def _getDesiredIndex(trackerdict):
     """
     Identify 'optimal' best key of trackerdict to use for visualizations.
-    Also return a view file based on geometry of that scene   
 
     Parameters
     ----------
@@ -230,20 +233,18 @@ def _getDesiredIndex(trackerdict):
 
     """
     import pandas as pd
-    viewfile = 'side.vp'  # default until we replace with something better
     
     df = pd.DataFrame.from_dict(trackerdict, orient='index')
     try:
         df = df[df['scene'].notna()]
     except KeyError:
         print('Error in _getDesiredIndex - trackerdict has no scene defined.')
-        return(df.index[-1], viewfile)
+        return df.index[-1]
     # try to find an index close to 25 degree tilt
     try:
         df['objective_fn'] = abs(df.surf_tilt - 25) # choose an index closest to 25 tilt with 
         bestkey = df['objective_fn'].idxmin()
     except:
         bestkey = df.index[-1]  # default to last index
-    
 
-    return(bestkey, viewfile)
+    return bestkey

--- a/bifacial_radiance/modelchain.py
+++ b/bifacial_radiance/modelchain.py
@@ -149,6 +149,15 @@ def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=N
         print('Bifacial ratio yearly average:  %0.3f' %
               (np.mean(analysis.Wm2Back) / np.mean(analysis.Wm2Front)))
 
+        if 'makeImage' in simulationParamsDict:
+            if simulationParamsDict['makeImage']:
+                try:
+                    print("Saving images")
+                    analysis.makeImage('side.vp')
+                    analysis.makeFalseColor('side.vp')
+                    module.saveImage()
+                except:
+                    print("Failed to make image")
     else:
     # Run everything through TrackerDict.    
 

--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -351,6 +351,8 @@ class ModuleObj(SuperClass):
         _,err = _popen(["rad",'-s',riffile], None)
         if err:
             print(err)
+        else:
+            print(f'Module image saved: images/{filename}_XYZ.hdr')
         
         temp_dir.cleanup()
         

--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -316,6 +316,46 @@ class ModuleObj(SuperClass):
                   ' into your RADIANCE binaries path')
             return 
 
+    def saveImage(self, filename=None):
+        """
+        Duplicate objview process to save an image of the module in /images/
+
+        Parameters:    
+            filename : string, optional. name for image file, defaults to module name               
+
+        """
+        import tempfile
+        
+        temp_dir = tempfile.TemporaryDirectory()
+        pid = os.getpid()
+        if filename is None:
+            filename = f'{self.name}'
+        # fake lighting temporary .radfile
+        ltfile = os.path.join(temp_dir.name, f'lt{pid}.rad')
+        with open(ltfile, 'w') as f:
+                f.write("void glow dim  0  0  4  .1 .1 .15  0\n" +\
+                    "dim source background  0  0  4  0 0 1  360\n"+\
+                    "void light bright  0  0  3  1000 1000 1000\n"+\
+                    "bright source sun1  0  0  4  1 .2 1  5\n"+\
+                    "bright source sun2  0  0  4  .3 1 1  5\n"+\
+                    "bright source sun3  0  0  4  -1 -.7 1  5")
+
+        # make .rif and run RAD
+        riffile = os.path.join(temp_dir.name, f'ov{pid}.rif')
+        with open(riffile, 'w') as f:
+                f.write("scene= materials/ground.rad " +\
+                        f"{self.modulefile} {ltfile}\n".replace("\\",'/') +\
+                    "EXPOSURE= .5\nUP= Z\nview= XYZ\n" +\
+                    #f"OCTREE= ov{pid}.oct\n"+\
+                    f"oconv= -f\nPICT= images/{filename}")
+        _,err = _popen(["rad",'-s',riffile], None)
+        if err:
+            print(err)
+        
+        temp_dir.cleanup()
+        
+    
+    
     def addTorquetube(self, diameter=0.1, tubetype='Round', material='Metal_Grey', 
                       axisofrotation=True, visible=True,  recompile=True):
         """

--- a/docs/sphinx/source/whatsnew/pending.rst
+++ b/docs/sphinx/source/whatsnew/pending.rst
@@ -1,0 +1,32 @@
+.. _whatsnew_0420:
+
+v0.4.2 (XX / XX / 2022)
+------------------------
+Release of new version including ...
+
+
+API Changes
+~~~~~~~~~~~~
+*A new function can now be called to compile results and report out final irradiance and performance data: :py:class:`~bifacial_radiance.RadianceObj.compileResults`.
+*Multiple modules and rows can now be selected in a single analysis scan. ``modWanted`` and ``rowWanted`` inputs in :py:class:`~bifacial_radiance.RadianceObj.analysis1axis` can now be a list, to select multiple rows and modules for scans. (:issue:`405`)(:pull:`408`)
+*To support multiple modules and row scans for 1axis simulations, outputs like Wm2Front are now stored in ``trackerdict``.``Results``  (:issue:`405`)(:pull:`408`)
+
+
+Enhancements
+~~~~~~~~~~~~
+* Adds new functions ModuleObj.saveImage and SceneObj.saveImage to save .hdr images of a module or scene. These are run by default in the modelchain if simulationParamsDict['saveImage'] = True. The gui will set saveImage = True by default.
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~~
+* Edge effects evaluation tutorial 23, with the new functionality of multiple modules/rows on the same analysis scan.
+
+
+Contributors
+~~~~~~~~~~~~
+* Silvana Ayala (:ghuser:`shirubana`)
+* Chris Deline (:ghuser:`cdeline`)

--- a/docs/sphinx/source/whatsnew/pending.rst
+++ b/docs/sphinx/source/whatsnew/pending.rst
@@ -1,6 +1,6 @@
-.. _whatsnew_0420:
+.. _whatsnew_0430:
 
-v0.4.2 (XX / XX / 2022)
+v0.4.3 (XX / XX / 2023)
 ------------------------
 Release of new version including ...
 
@@ -14,7 +14,6 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
-* Adds new functions ModuleObj.saveImage and SceneObj.saveImage to save .hdr images of a module or scene. These are run by default in the modelchain if simulationParamsDict['saveImage'] = True. The gui will set saveImage = True by default.
 
 
 Bug fixes

--- a/docs/sphinx/source/whatsnew/v0.4.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.4.2.rst
@@ -2,7 +2,7 @@
 
 v0.4.2 (03 / 09 / 2023)
 ------------------------
-Minor bug fix update
+Documentation, bug fix and enhancement update
 
 
 Documentation
@@ -19,17 +19,18 @@ Bug fixes
 * Return functionality that existed previous to 0.4.0:  :py:class:`~bifacial_radiance.ModuleObj`. ``text`` can be manually passed in, over-riding the module object definition.  This was mistakenly removed during the moduleObj refactor. (:pull:`413`)(:issue:`390`)
 
 
-API Changes
-~~~~~~~~~~~~
-
 
 Enhancements
 ~~~~~~~~~~~~
+* Adds new functions :py:class:`~bifacial_radiance.ModuleObj`. ``saveImage`` and :py:class:`~bifacial_radiance.SceneObj`. ``saveImage`` to save .hdr images of a module or scene. These are run by default in the modelchain if simulationParamsDict['saveImage'] = True. The gui will set saveImage = True by default.
 
 
 Deprecations
 ~~~~~~~~~~~~~~
 
+API Changes
+~~~~~~~~~~~~
+*  :py:class:`~bifacial_radiance.GroundObj` has new parameter ``silent`` to suppress print statements.  Default: `False` 
 
 
 

--- a/docs/sphinx/source/whatsnew/v0.4.2.rst
+++ b/docs/sphinx/source/whatsnew/v0.4.2.rst
@@ -22,16 +22,20 @@ Bug fixes
 
 Enhancements
 ~~~~~~~~~~~~
-* Adds new functions :py:class:`~bifacial_radiance.ModuleObj`. ``saveImage`` and :py:class:`~bifacial_radiance.SceneObj`. ``saveImage`` to save .hdr images of a module or scene. These are run by default in the modelchain if simulationParamsDict['saveImage'] = True. The gui will set saveImage = True by default.
-
+* Adds new functions :py:class:`~bifacial_radiance.ModuleObj`. ``saveImage`` and :py:class:`~bifacial_radiance.SceneObj`. ``saveImage`` to save .hdr images of a module or scene. 
+* New ``saveImage`` functions are run by default in the modelchain if simulationParamsDict['saveImage'] = True. The gui will set saveImage = True by default.
+* If a 1-axis simulation is run from modelchain and simulationParamsDict['saveImage'] = True, :py:class:`~bifacial_radiance.SceneObj`. ``saveImage`` will render a scene with the tracker angle closest to 20 degree tilt
 
 Deprecations
 ~~~~~~~~~~~~~~
+*  :py:class:`~bifacial_radiance.RadianceObj`.``nMods`` and ``nRows`` internal parameter has been removed. These are now defined per :py:class:`~bifacial_radiance.SceneObj`.sceneDict 
+*  `trackerdict[index]['clearance_height']` parameter has been removed. These are available inside the trackerdict[index]['scene'] :py:class:`~bifacial_radiance.SceneObj` .sceneDict
+
 
 API Changes
 ~~~~~~~~~~~~
 *  :py:class:`~bifacial_radiance.GroundObj` has new parameter ``silent`` to suppress print statements.  Default: `False` 
-
+*  :py:class:`~bifacial_radiance.SceneObj` has new parameter ``name`` to identify it in upcoming multi-scene simulations.  Default: `Scene0`
 
 
 

--- a/docs/tutorials/1 - Introductory Example - Fixed Tilt simple setup.ipynb
+++ b/docs/tutorials/1 - Introductory Example - Fixed Tilt simple setup.ipynb
@@ -170,7 +170,7 @@
      "text": [
       "\n",
       "Input albedo 0-1, or string from ground.printGroundMaterials().\n",
-      "Alternatively, run setGround after readWeatherData()and setGround will read metdata.albedo if availalbe\n"
+      "Alternatively, run setGround after readWeatherData()and setGround will read metdata.albedo if available\n"
      ]
     }
    ],
@@ -359,6 +359,7 @@
       "Module Name: test-module\n",
       "Module test-module updated in module.json\n",
       "Pre-existing .rad file objects\\test-module.rad will be overwritten\n",
+      "\n",
       "{'x': 1.695, 'y': 0.984, 'z': 0.02, 'modulematerial': 'black', 'scenex': 1.705, 'sceney': 0.984, 'scenez': 0.1, 'numpanels': 1, 'bifi': 1, 'text': '! genbox black test-module 1.695 0.984 0.02 | xform -t -0.8475 -0.492 0 -a 1 -t 0 0.984 0', 'modulefile': 'objects\\\\test-module.rad', 'glass': False, 'offsetfromaxis': 0, 'xgap': 0.01, 'ygap': 0.0, 'zgap': 0.1}\n"
      ]
     }
@@ -386,7 +387,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Available module names: ['2upTracker', 'Bi60', 'Custom Tracker Module', 'Prism Solar Bi60', 'Prism Solar Bi60 landscape', 'PrismSolar', 'Sharp_NU-U235F2', 'cellModule', 'hex', 'oct', 'round', 'sensor', 'square', 'test', 'test-module']\n"
+      "Available module names: ['PrismSolar-Bi60', 'basic-module', 'test-module']\n"
      ]
     }
    ],
@@ -880,6 +881,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Scene image saved: images/Scene0_side.hdr\n",
       "Generating visible render of scene\n",
       "Generating scene in WM-2. This may take some time.\n",
       "Saving scene in false color\n"
@@ -887,6 +889,8 @@
     }
    ],
    "source": [
+    "# Print a default image of the module and scene that is saved in /images/ folder. (new in v0.4.2)\n",
+    "scene.saveImage()\n",
     "\n",
     "# Make a color render and falsecolor image of the scene.\n",
     "analysis.makeImage('side.vp')\n",

--- a/docs/tutorials/1 - Introductory Example - Fixed Tilt simple setup.py
+++ b/docs/tutorials/1 - Introductory Example - Fixed Tilt simple setup.py
@@ -333,6 +333,8 @@ print('Annual bifacial ratio: %0.2f ' %( np.mean(analysis.Wm2Back) * bifaciality
 # In[22]:
 
 
+# Print a default image of the module and scene that is saved in /images/ folder. (new in v0.4.2)
+scene.saveImage()
 
 # Make a color render and falsecolor image of the scene.
 analysis.makeImage('side.vp')

--- a/tests/ini_highAzimuth.ini
+++ b/tests/ini_highAzimuth.ini
@@ -14,6 +14,7 @@ cumulativeSky: False
 selectTimes: True
 latitude: 37.5
 longitude: -77.6
+saveImage = True
 
 [timeControlParamsDict]
 starttime: 06_17_13

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -174,9 +174,9 @@ def test_RadianceObj_1axis_gendaylit_end_to_end():
     #V 0.2.5 fixed the gcr passed to set1axis. (since gcr was not being passd to set1axis, gcr was default 0.33 default). 
     assert(np.mean(demo.Wm2Front) == pytest.approx(205.0, 0.01) ) # was 214 in v0.2.3  # was 205 in early v0.2.4  
     assert(np.mean(demo.Wm2Back) == pytest.approx(43.0, 0.1) )
-    #assert demo.trackerdict['2001-01-01_1100']['scene'].text.__len__() == 132
-    #assert demo.trackerdict['2001-01-01_1100']['scene'].text[23:28] == " 2.0 "
-    #demo.exportTrackerDict(savefile = 'results\exportedTrackerDict.csv', reindex=True)
+    assert demo.trackerdict['2001-01-01_1100']['scene'].text.__len__() == 132
+    assert demo.trackerdict['2001-01-01_1100']['scene'].text[23:28] == " 2.0 "
+    demo.exportTrackerDict(savefile = 'results\exportedTrackerDict.csv', reindex=True)
 """
 
 def test_1axis_gencumSky():

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -105,14 +105,14 @@ def test_RadianceObj_high_azimuth_angle_end_to_end():
     demo = bifacial_radiance.RadianceObj(name)  # Create a RadianceObj 'object'
     demo.setGround('white_EPDM') # input albedo number or material name like 'concrete'.  To see options, run this without any input.
   
-    #metdata = demo.readEPW() # read in the EPW weather data from above
-    metdata = demo.readTMY(MET_FILENAME2) # select a TMY file using graphical picker
+    metdata = demo.readWeatherFile(MET_FILENAME2, coerce_year=2001) # select a TMY file using graphical picker
     # Now we either choose a single time point, or use cumulativesky for the entire year. 
     fullYear = False
     if fullYear:
         demo.genCumSky(demo.epwfile) # entire year.  # Don't know how to test this yet in pytest...
     else:
-        demo.gendaylit(metdata=metdata,timeindex=4020)  # Noon, June 17th
+        timeindex = metdata.datetime.index(pd.to_datetime('2001-06-17 12:0:0 -7'))
+        demo.gendaylit(metdata=metdata,timeindex=timeindex)  # Noon, June 17th
     # create a scene using panels in landscape at 10 deg tilt, 1.5m pitch. 0.2 m ground clearance
     sceneDict = {'tilt':10,'pitch':1.5,'height':0.2,'azimuth':30, 'nMods':10, 'nRows':3}  
     module = demo.makeModule(name='test-module',y=0.95,x=1.59, xgap=0)

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -174,6 +174,9 @@ def test_RadianceObj_1axis_gendaylit_end_to_end():
     #V 0.2.5 fixed the gcr passed to set1axis. (since gcr was not being passd to set1axis, gcr was default 0.33 default). 
     assert(np.mean(demo.Wm2Front) == pytest.approx(205.0, 0.01) ) # was 214 in v0.2.3  # was 205 in early v0.2.4  
     assert(np.mean(demo.Wm2Back) == pytest.approx(43.0, 0.1) )
+    #assert demo.trackerdict['2001-01-01_1100']['scene'].text.__len__() == 132
+    #assert demo.trackerdict['2001-01-01_1100']['scene'].text[23:28] == " 2.0 "
+    #demo.exportTrackerDict(savefile = 'results\exportedTrackerDict.csv', reindex=True)
 """
 
 def test_1axis_gencumSky():


### PR DESCRIPTION
Continuation of pull #422 for v0.4.2 release.

Adds new functions ModuleObj.saveImage and SceneObj.saveImage to save .hdr images of a module or scene.  These are run by default in the modelchain if simulationParamsDict['saveImage'] = True.  The gui will set  saveImage = True by default.

- [X] Pytests
- [X] Docstrings
- [x] Tutorials updated
- [x] whatsnew