### PR TITLE
Update ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+   os: ubuntu-20.04
+   tools:
+     python: "3.8"
+
 python:
-    version: "3.8"
     install:
         - method: pip
           path: .


### PR DESCRIPTION
ReadTheDocs is requiring a change in the configuration file (see the warning on this [build](https://readthedocs.org/projects/bifacial-radiance/builds/21983094/)):

> Your builds will stop working soon!
> "build.image" config key is deprecated and it will be removed soon. [Read our blog post to know how to migrate to new key "build.os"](https://blog.readthedocs.com/use-build-os-config/) and ensure your project continues building successfully.

This PR updates the configuration file to the current recommended state.