### PR TITLE
Add 'columns' and 'methods' introspection to RadObj, MetObj and GrounObj

### DIFF
--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -3166,7 +3166,8 @@ class GroundObj:
     -------
 
     """
-   
+    def __repr__(self):
+        return str(self.__dict__)   
     def __init__(self, materialOrAlbedo=None, material_file=None, silent=False):
         import warnings
         from numbers import Number

--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -377,6 +377,12 @@ class RadianceObj:
             self._setPath(path)
         # load files in the /materials/ directory
         self.materialfiles = self.returnMaterialFiles('materials')
+        
+        # store list of columns and methods for convenience / introspection
+        # TODO: abstract this by making a super class that this inherits
+        self.columns =  [attr for attr in dir(self) if not (attr.startswith('_') or callable(getattr(self,attr)))]
+        self.methods = [attr for attr in dir(self) if (not attr.startswith('_') and callable(getattr(self,attr)))]
+
 
     def _setPath(self, path):
         """
@@ -3237,6 +3243,11 @@ class GroundObj:
         except IndexError as e:
             print('albedo.shape should be 3 column (N x 3)')
             raise e
+            
+        # store list of columns and methods for convenience / introspection
+        # TODO: abstract this by making a super class that this inherits
+        self.columns =  [attr for attr in dir(self) if not (attr.startswith('_') or callable(getattr(self,attr)))]
+        self.methods = [attr for attr in dir(self) if (not attr.startswith('_') and callable(getattr(self,attr)))]
     
     def printGroundMaterials(self, materialString=None):
         """
@@ -3642,9 +3653,18 @@ class MetObj:
         example, TMY3 data is right-labeled, so 11 AM data represents data from
         10 to 11, and sun position should be calculated at 10:30 AM.  Currently
         SAM and PVSyst use left-labeled interval data and NSRDB uses centered.
+        
+    Once initialized, the following parameters are available in the MetObj:
+        -latitude, longitude, elevation, timezone, city [scalar values]
+        
+        -datetime, ghi, dhi, dni, albedo, dewpoint, pressure, temp_air, 
+        wind_speed, meastracker_angle [numpy.array]
+        
+        -solpos [pandas dataframe of solar position]
 
     """
-
+    def __repr__(self):
+        return str(self.__dict__)  
     def __init__(self, tmydata, metadata, label = 'right'):
 
         import pytz
@@ -3778,7 +3798,7 @@ class MetObj:
         self.solpos = pvlib.irradiance.solarposition.get_solarposition(sunup['corrected_timestamp'],lat,lon,elev)
         self.sunrisesetdata=sunup
         self.label = label
-
+        self.columns =  [attr for attr in dir(self) if not attr.startswith('_')]
 
     def _set1axis(self, azimuth=180, limit_angle=45, angledelta=None, 
                   backtrack=True, gcr=1.0/3.0, cumulativesky=True, 

--- a/docs/sphinx/source/whatsnew/pending.rst
+++ b/docs/sphinx/source/whatsnew/pending.rst
@@ -16,7 +16,7 @@ API Changes
 
 Enhancements
 ~~~~~~~~~~~~
-
+* :py:class:`~bifacial_radiance.RadianceObj` and :py:class:`~bifacial_radiance.GroundObj` and :py:class:`~bifacial_radiance.MetObj` now have `self.columns` and `self.methods` introspection to list data columsn and methods available
 
 
 

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -48,7 +48,9 @@ def test_RadianceObj_set1axis():
     # test set1axis.  requires metdata for boulder. 
     name = "_test_set1axis"
     demo = bifacial_radiance.RadianceObj(name)
-    assert str(demo)[-16:-2]==name #this depends on the insertion order of the dictionary repr of demo - may not be consistent
+    assert str(demo).__len__() > 1000 #this depends on the insertion order of the dictionary repr of demo - may not be consistent
+    assert demo.columns.__len__() >= 15
+    assert demo.methods.__len__() >= 30
     #try:
     #    epwfile = demo.getEPW(lat=40.01667, lon=-105.25)  # From EPW: {N 40°  1'} {W 105° 15'}
     #except: # adding an except in case the internet connection in the lab forbids the epw donwload.


### PR DESCRIPTION
This allows you to view available methods more easily by calling `radObj.columns` or `radObj.methods`, similar to a dataframe.
MetObj technically only gets `.columns` introspection.  MetObj also gets a _repr_ function if you want to print it.