### PR TITLE
add pyRadiance to setup.py install_requires to help with RADIANCE install issues.

### DIFF
--- a/docs/sphinx/source/whatsnew/pending.rst
+++ b/docs/sphinx/source/whatsnew/pending.rst
@@ -16,6 +16,7 @@ API Changes
 Enhancements
 ~~~~~~~~~~~~
 * Added :func:`bifacial_radiance.mismatch.mismatch_fit2`, similar to :func:`bifacial_radiance.mismatch.mismatch_fit3`, with the recommended coefficients of the original publication. (:pull:`520`)
+* Including `pyRadiance` as a requirement to help streamline RADIANCE installation and calls in a future release. (:pull:`532`)
 
 Bug fixes
 ~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         'pvmismatch',
         'configparser',
         'requests',
-        
+        'pyradiance',
         ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Full use of pyRadiance will happen in a subsequent PR.