### PR TITLE
files saved to \results\ with 3 decimal floats.

### DIFF
--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -3877,8 +3877,8 @@ class AnalysisObj:
             setattr(self, col, list(df[col]))    
         # only save a subset
         df = df.drop(columns=['rearX','rearY','backRatio'], errors='ignore')
-        df.to_csv(os.path.join("results", savefile), sep = ',',
-                           index = False)
+        df.to_csv(os.path.join("results", savefile), sep=',',
+                           index=False, float_format='%0.3f')
 
 
         print('Saved: %s'%(os.path.join("results", savefile)))
@@ -3922,12 +3922,12 @@ class AnalysisObj:
             df.to_csv(savefile, sep = ',',
                       columns = ['x','y','z','rearZ','mattype','rearMat',
                                  'Wm2Front','Wm2Back','Back/FrontRatio'],
-                                 index = False) # new in 0.2.3
+                                 index=False, float_format='%0.3f') # new in 0.2.3
 
         else:
             df = pd.DataFrame.from_dict(data_sub)
-            df.to_csv(savefile, sep = ',',
-                      columns = ['x','y','z', 'mattype','Wm2'], index = False)
+            df.to_csv(savefile, sep=',', float_format='%0.3f',
+                      columns=['x','y','z', 'mattype','Wm2'], index=False)
 
         print('Saved: %s'%(savefile))
         return (savefile)   

--- a/docs/sphinx/source/whatsnew.rst
+++ b/docs/sphinx/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.4.3.rst
 .. include:: whatsnew/v0.4.2.rst
 .. include:: whatsnew/v0.4.1.rst
 .. include:: whatsnew/v0.4.0.rst

--- a/docs/sphinx/source/whatsnew/v0.4.3.rst
+++ b/docs/sphinx/source/whatsnew/v0.4.3.rst
@@ -36,6 +36,7 @@ Documentation
 * Edge effects evaluation tutorial 23, with the new functionality of multiple modules/rows on the same analysis scan.
 * Updates to example notebooks 
 * Reduce number of digits in makeScene .rad file titles. (:pull:`503`)
+* Reduce number of digits saved to files in \results  (:pull:`534`)
 * In the sceneDict reported in the trackerdict, save both `clearance_height` and `hub_height` parameters. (:pull:`503`)
 
 Contributors


### PR DESCRIPTION
get rid of Y position = 1.54234E-14  or whatever.  And cuts down on extraneous digits of precision in Wm2 irradiance values too.