### PR TITLE
Add checks for RAYPATH.  Fixes #525

### DIFF
--- a/bifacial_radiance/main.py
+++ b/bifacial_radiance/main.py
@@ -302,7 +302,24 @@ def _subhourlydatatoGencumskyformat(gencumskydata, label='right'):
     if (gencumskydata.index.year[-1] == gencumskydata.index.year[-2]+1) and len(gencumskydata)>8760:
         gencumskydata = gencumskydata[:-1]
     return gencumskydata
-    # end _subhourlydatatoGencumskyformat        
+    # end _subhourlydatatoGencumskyformat   
+
+def _checkRaypath():
+    # Ensure that os.environ['RAYPATH'] exists and contains current directory '.'     
+    if os.name == 'nt':
+        splitter = ';'
+    else:
+        splitter = ':'
+    try:
+        raypath = os.getenv('RAYPATH', default=None)
+        if not raypath:
+            raise KeyError()
+        raysplit = raypath.split(splitter)
+        if not '.' in raysplit:
+            os.environ['RAYPATH'] = splitter.join(filter(None, raysplit + ['.'+splitter]))
+    except (KeyError, AttributeError, TypeError):
+        raise Exception('No RAYPATH set for RADIANCE.  Please check your RADIANCE installation.')
+        
     
 
 class RadianceObj:
@@ -361,6 +378,7 @@ class RadianceObj:
         
         now = datetime.datetime.now()
         self.nowstr = str(now.date())+'_'+str(now.hour)+str(now.minute)+str(now.second)
+        _checkRaypath()       # make sure we have RADIANCE path set up correctly
 
         # DEFAULTS
 

--- a/docs/sphinx/source/whatsnew/pending.rst
+++ b/docs/sphinx/source/whatsnew/pending.rst
@@ -1,0 +1,28 @@
+.. _whatsnew_0440:
+
+v0.4.4 (XX / XX / 2024)
+------------------------
+Bugfix Release  ...
+
+
+API Changes
+~~~~~~~~~~~~
+* 
+
+Enhancements
+~~~~~~~~~~~~
+* Conduct an automated check for proper radiance RAYPATH setting (:issue:`525`)
+
+
+Bug fixes
+~~~~~~~~~
+* 
+
+Documentation
+~~~~~~~~~~~~~~
+* 
+
+Contributors
+~~~~~~~~~~~~
+* Silvana Ayala (:ghuser:`shirubana`)
+* Chris Deline (:ghuser:`cdeline`)

--- a/tests/test_bifacial_radiance.py
+++ b/tests/test_bifacial_radiance.py
@@ -576,3 +576,17 @@ def test_customTrackerAngles():
     assert trackerdict[-20]['count'] == 3440
     trackerdict = demo.set1axis(azimuth=90, useMeasuredTrackerAngle=False)
     assert trackerdict[-20]['count'] == 37
+    
+def test_raypath():
+    # test errors and raypath updates
+    import re
+    raypath0 = os.getenv('RAYPATH', default=None)
+    
+    os.environ['RAYPATH'] = ''
+    with pytest.raises(Exception):
+        bifacial_radiance.main._checkRaypath()
+    os.environ['RAYPATH'] = 'test'
+    bifacial_radiance.main._checkRaypath()
+    assert '.' in re.split(':|;', os.environ['RAYPATH'])
+    
+    os.environ['RAYPATH'] = raypath0    


### PR DESCRIPTION
This pull request checks to make sure that RAYPATH is at least set with the current directory ('.').  If it's completely blank, it will error out with an informative message to check your RADIANCE installation, since those executables are probably not on the PATH.  If it's a partial install with just the executables, then it will silently add the current directory ('.') to RAYPATH when RadianceObj is first initialized