### PR TITLE
438 inifile change load.py to include more module inputs

### DIFF
--- a/bifacial_radiance/load.py
+++ b/bifacial_radiance/load.py
@@ -524,7 +524,7 @@ def readconfigurationinputfile(inifile=None):
             
     if simulationParamsDict['selectTimes']:
         if config.has_section("timeControlParamsDict"):
-            timeControlParamsDict = boolConvert(confdict['timeControlParamsDict'])
+            timeControlParamsDict = confdict['timeControlParamsDict']
            
     if simulationParamsDict['getEPW']:
         try:
@@ -588,16 +588,16 @@ def readconfigurationinputfile(inifile=None):
             moduleParamsDict['glassEdge'] = moduleParamsDict2['glassEdge']
         if simulationParamsDict['cellLevelModule']:    
             if config.has_section("cellLevelModuleParamsDict"):
-                cellLevelModuleParamsDict = confdict['cellLevelModuleParamsDict']
+                cellModuleDict = confdict['cellLevelModuleParamsDict']
                 try: # being lazy so just validating the whole dictionary as a whole. #TODO: validate individually maybe.            
-                    cellLevelModuleParamsDict['numcellsx'] = int(cellLevelModuleParamsDict['numcellsx'])
-                    cellLevelModuleParamsDict['numcellsy'] = int(cellLevelModuleParamsDict['numcellsy'])
-                    cellLevelModuleParamsDict['xcell'] = round(float(cellLevelModuleParamsDict['xcell']),3)
-                    cellLevelModuleParamsDict['xcellgap'] = round(float(cellLevelModuleParamsDict['xcellgap']),3)
-                    cellLevelModuleParamsDict['ycell'] = round(float(cellLevelModuleParamsDict['ycell']),3)
-                    cellLevelModuleParamsDict['ycellgap'] = round(float(cellLevelModuleParamsDict['ycellgap']),3)
-                    if 'centerJB' in cellLevelModuleParamsDict:
-                        cellLevelModuleParamsDict['centerJB'] = round(float(cellLevelModuleParamsDict['centerJB']),3)
+                    cellModuleDict['numcellsx'] = int(cellModuleDict['numcellsx'])
+                    cellModuleDict['numcellsy'] = int(cellModuleDict['numcellsy'])
+                    cellModuleDict['xcell'] = round(float(cellModuleDict['xcell']),3)
+                    cellModuleDict['xcellgap'] = round(float(cellModuleDict['xcellgap']),3)
+                    cellModuleDict['ycell'] = round(float(cellModuleDict['ycell']),3)
+                    cellModuleDict['ycellgap'] = round(float(cellModuleDict['ycellgap']),3)
+                    if 'centerJB' in cellModuleDict:
+                        cellModuleDict['centerJB'] = round(float(cellModuleDict['centerJB']),3)
                 except: 
                     print("Load Warning: celllevelModule set to True,",\
                           "but celllevelModule parameters are missing/not numbers.")
@@ -612,12 +612,12 @@ def readconfigurationinputfile(inifile=None):
                     except:
                         print("Attempted to load x and y instead of celllevelModule parameters,",\
                               "Failed, so default values for cellLevelModule will be passed")
-                        cellLevelModuleParamsDict['numcellsx'] = 12
-                        cellLevelModuleParamsDict['numcellsy'] = 6
-                        cellLevelModuleParamsDict['xcell'] = 0.15
-                        cellLevelModuleParamsDict['xcellgap'] = 0.1
-                        cellLevelModuleParamsDict['ycell'] = 0.15 
-                        cellLevelModuleParamsDict['ycellgap'] = 0.1
+                        cellModuleDict['numcellsx'] = 12
+                        cellModuleDict['numcellsy'] = 6
+                        cellModuleDict['xcell'] = 0.15
+                        cellModuleDict['xcellgap'] = 0.1
+                        cellModuleDict['ycell'] = 0.15 
+                        cellModuleDict['ycellgap'] = 0.1
             else: # no cellleveldictionary passed
                 print("Load Warning: celllevelmodule selected, but no dictionary was passed in input file.",\
                       "attempting to proceed with regular custom module and setting celllevelmodule to false")
@@ -783,15 +783,21 @@ def readconfigurationinputfile(inifile=None):
     try: analysisParamsDict
     except: analysisParamsDict = None
     
-    try: cellLevelModuleParamsDict
-    except: cellLevelModuleParamsDict = None
+    try: cellModuleDict
+    except: cellModuleDict = None
     
-    #returnParams = Params(simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellLevelModuleParamsDict)
+    #returnParams = Params(simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellModuleDict)
     #return returnParams
-    return simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellLevelModuleParamsDict, frameParamsDict, omegaParamsDict
+    return (simulationParamsDict, sceneParamsDict, timeControlParamsDict, 
+            moduleParamsDict, trackingParamsDict, torquetubeParamsDict, 
+            analysisParamsDict, cellModuleDict, frameParamsDict, omegaParamsDict)
 
 
-def savedictionariestoConfigurationIniFile(simulationParamsDict, sceneParamsDict, timeControlParamsDict=None, moduleParamsDict=None, trackingParamsDict=None, torquetubeParamsDict=None, analysisParamsDict=None, cellLevelModuleParamsDict=None, inifilename=None):
+def savedictionariestoConfigurationIniFile(simulationParamsDict, sceneParamsDict, 
+                                           timeControlParamsDict=None, moduleParamsDict=None, 
+                                           trackingParamsDict=None, torquetubeParamsDict=None, 
+                                           analysisParamsDict=None, cellModuleDict=None, 
+                                           frameParamsDict=None, omegaParamsDict=None, inifilename=None):
     """
     Saves dictionaries from working memory into a Configuration File
     with extension format .ini.
@@ -810,7 +816,7 @@ def savedictionariestoConfigurationIniFile(simulationParamsDict, sceneParamsDict
         Default None 
     analysisParamsDict
         Default None, 
-    cellLevelModuleParamsDict
+    cellModuleDict
         Default None    
     
     Returns
@@ -841,8 +847,16 @@ def savedictionariestoConfigurationIniFile(simulationParamsDict, sceneParamsDict
     try: config['analysisParamsDict'] = analysisParamsDict
     except: pass
     
-    try: config['cellLevelModuleParamsDict'] = cellLevelModuleParamsDict
+    try: config['cellLevelModuleParamsDict'] = cellModuleDict
     except: pass
+
+    if frameParamsDict:    
+        try: config['frameParamsDict'] = frameParamsDict
+        except: pass
+
+    if omegaParamsDict:
+        try: config['omegaParamsDict'] = omegaParamsDict
+        except: pass
 
     if inifilename is None:
         inifilename = 'example.ini'

--- a/bifacial_radiance/load.py
+++ b/bifacial_radiance/load.py
@@ -489,13 +489,17 @@ def readconfigurationinputfile(inifile=None):
     import ast
     
     def boolConvert(d):
-        """ convert strings 'True' and 'False' to boolean
+        """ convert strings 'True' and 'False' to boolean and convert numbers to float
         """
         for key,value in d.items():
             if value.lower() == 'true': 
                 d[key] = True
             elif value.lower() == 'false':
                 d[key] = False
+            try:
+                d[key] = float(value)
+            except ValueError:
+                pass
         return d
     
     if inifile is None:
@@ -589,6 +593,8 @@ def readconfigurationinputfile(inifile=None):
                     cellLevelModuleParamsDict['xcellgap'] = round(float(cellLevelModuleParamsDict['xcellgap']),3)
                     cellLevelModuleParamsDict['ycell'] = round(float(cellLevelModuleParamsDict['ycell']),3)
                     cellLevelModuleParamsDict['ycellgap'] = round(float(cellLevelModuleParamsDict['ycellgap']),3)
+                    if 'centerJB' in cellLevelModuleParamsDict:
+                        cellLevelModuleParamsDict['centerJB'] = round(float(cellLevelModuleParamsDict['centerJB']),3)
                 except: 
                     print("Load Warning: celllevelModule set to True,",\
                           "but celllevelModule parameters are missing/not numbers.")
@@ -673,7 +679,14 @@ def readconfigurationinputfile(inifile=None):
         
     
     if simulationParamsDict['tracking']:
-        sceneParamsDict['axis_azimuth']=round(float(sceneParamsDict2['axis_azimuth']),2)
+        if 'axis_aziumth' in sceneParamsDict2:
+            azimuth = sceneParamsDict2['axis_azimuth']
+        elif sceneParamsDict2.get('azimuth'):
+            azimuth = sceneParamsDict2.get('azimuth')
+        else:
+            raise Exception(f'Neither "axis_azimuth" or "azimuth" in .inifile {inifile}' )
+            
+        sceneParamsDict['azimuth']=round(float(azimuth),2)
         sceneParamsDict['hub_height']=round(float(sceneParamsDict2['hub_height']),2)
         
         if config.has_section("trackingParamsDict"):
@@ -743,6 +756,14 @@ def readconfigurationinputfile(inifile=None):
             analysisParamsDict['rowWanted'] = None #Default
             print("analysisParamsDict['rowWanted'] set to middle row by default" )    
     
+    if "frameParamsDict" in confdict:
+        frameParamsDict = boolConvert(confdict['frameParamsDict'])
+    else:
+        frameParamsDict = None
+    if "omegaParamsDict" in confdict:
+        omegaParamsDict = boolConvert(confdict['omegaParamsDict'])
+    else:
+        omegaParamsDict = None
     # Creating None dictionaries for those empty ones
     try: timeControlParamsDict
     except: timeControlParamsDict = None
@@ -764,7 +785,7 @@ def readconfigurationinputfile(inifile=None):
     
     #returnParams = Params(simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellLevelModuleParamsDict)
     #return returnParams
-    return simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellLevelModuleParamsDict
+    return simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellLevelModuleParamsDict, frameParamsDict, omegaParamsDict
 
 
 def savedictionariestoConfigurationIniFile(simulationParamsDict, sceneParamsDict, timeControlParamsDict=None, moduleParamsDict=None, trackingParamsDict=None, torquetubeParamsDict=None, analysisParamsDict=None, cellLevelModuleParamsDict=None, inifilename=None):

--- a/bifacial_radiance/load.py
+++ b/bifacial_radiance/load.py
@@ -582,7 +582,10 @@ def readconfigurationinputfile(inifile=None):
         except:
             moduleParamsDict['zgap'] = 0.1 #Default
             print("Load Warning: moduleParamsDict['zgap'] not specified, setting to default value: %s" % moduleParamsDict['zgap'] ) 
-                    
+        if 'glass' in moduleParamsDict2:
+            moduleParamsDict['glass'] = moduleParamsDict2['glass']
+        if moduleParamsDict2.get('glassEdge'):
+            moduleParamsDict['glassEdge'] = moduleParamsDict2['glassEdge']
         if simulationParamsDict['cellLevelModule']:    
             if config.has_section("cellLevelModuleParamsDict"):
                 cellLevelModuleParamsDict = confdict['cellLevelModuleParamsDict']

--- a/bifacial_radiance/load.py
+++ b/bifacial_radiance/load.py
@@ -477,8 +477,10 @@ def readconfigurationinputfile(inifile=None):
     trackingParamsDict : Dictionary
     torquetubeParamsDict : Dictionary
     analysisParamsDict : Dictionary
-    cellLevelModuleParamsDict : Dictionary
-
+    cellModuleDict : Dictionary
+    frameParamsDict : Dictionary
+    omegaParamsDict : Dictionary
+    
     """
 
     ## #TODO: check if modulename exists on jason and rewrite is set to false, then

--- a/bifacial_radiance/modelchain.py
+++ b/bifacial_radiance/modelchain.py
@@ -27,7 +27,8 @@ def _append_dicts(x, y):
 
 def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=None, 
                   moduleParamsDict=None, trackingParamsDict=None, torquetubeParamsDict=None, 
-                  analysisParamsDict=None, cellModuleDict=None):
+                  analysisParamsDict=None, cellModuleDict=None, frameParamsDict=None,
+                  omegaParamsDict=None):
     """
     This calls config.py values, which are arranged into dictionaries,
     and runs all the respective processes based on the variables in the config.py.
@@ -55,16 +56,19 @@ def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=N
     demo = bifacial_radiance.RadianceObj(
         simulationParamsDict['simulationname'], path=testfolder)  # Create a RadianceObj 'object'
 
+
     # Save INIFILE in folder
     inifilename = os.path.join(
         simulationParamsDict['testfolder'],  'simulation.ini')
     bifacial_radiance.load.savedictionariestoConfigurationIniFile(simulationParamsDict, sceneParamsDict, timeControlParamsDict,
-                                                                  moduleParamsDict, trackingParamsDict, torquetubeParamsDict, analysisParamsDict, cellModuleDict, inifilename)
+                                                                  moduleParamsDict, trackingParamsDict, torquetubeParamsDict, 
+                                                                  analysisParamsDict, cellModuleDict, frameParamsDict, omegaParamsDict,
+                                                                  inifilename)
    
     # re-load configuration file to make sure all booleans are converted
     (simulationParamsDict, sceneParamsDict, timeControlParamsDict, 
      moduleParamsDict, trackingParamsDict,torquetubeParamsDict,
-     analysisParamsDict,cellModuleDict) = \
+     analysisParamsDict, cellModuleDict, frameParamsDict, omegaParamsDict) = \
         bifacial_radiance.load.readconfigurationinputfile(inifilename)
     
     # Load weatherfile
@@ -121,14 +125,15 @@ def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=N
             
             module = demo.makeModule(name=simulationParamsDict['moduletype'],
                                          tubeParams=torquetubeParamsDict,
-                                         cellModule=cellModule, **kwargs)
+                                         cellModule=cellModule,  **kwargs)
 
         print("\nUsing Pre-determined Module Type: %s " %
               simulationParamsDict['moduletype'])
     else:
         module = demo.makeModule(name=simulationParamsDict['moduletype'],
                                      tubeParams=torquetubeParamsDict,
-                                     cellModule=cellModule, **kwargs)
+                                     cellModule=cellModule, frameParams=frameParamsDict,
+                                     omegaParams=omegaParamsDict, **kwargs)
 
     
     if 'gcr' not in sceneParamsDict:  # didn't get gcr passed - need to calculate it

--- a/bifacial_radiance/modelchain.py
+++ b/bifacial_radiance/modelchain.py
@@ -152,6 +152,9 @@ def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=N
 
     else:
     # Run everything through TrackerDict.    
+        # check for deprecated axis_azimuth
+        if  (sceneParamsDict.get('axis_azimuth') is not None) and (sceneParamsDict.get('azimuth') is None):
+            sceneParamsDict['azimuth'] = sceneParamsDict['axis_azimuth']
 
         if simulationParamsDict['tracking'] == False:
             trackerdict = demo.set1axis(metdata, 
@@ -160,7 +163,7 @@ def runModelChain(simulationParamsDict, sceneParamsDict, timeControlParamsDict=N
                                         azimuth=sceneParamsDict['azimuth']) 
         else:
             trackerdict = demo.set1axis(metdata, gcr=sceneParamsDict['gcr'],
-                                        azimuth=sceneParamsDict['axis_azimuth'],
+                                        azimuth=sceneParamsDict['azimuth'],
                                         limit_angle=trackingParamsDict['limit_angle'],
                                         angledelta=trackingParamsDict['angle_delta'],
                                         backtrack=trackingParamsDict['backtrack'],

--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -438,7 +438,7 @@ class ModuleObj(SuperClass):
         recompile : Bool          Rewrite .rad file and module.json file (default True)
 
         """
-        self.omega = Omega(self, omega_material=omega_material,
+        self.omega = Omega(module=self, omega_material=omega_material,
                            omega_thickness=omega_thickness,
                            inverted=inverted, x_omega1=x_omega1,
                            x_omega3=x_omega3, y_omega=y_omega, 

--- a/bifacial_radiance/module.py
+++ b/bifacial_radiance/module.py
@@ -145,6 +145,11 @@ class ModuleObj(SuperClass):
             except AttributeError:
                 self.axisofrotationTorqueTube = False
             """
+            
+            # set data object attributes from datakey list. 
+            for key in self.keys:
+                setattr(self, key, eval(key)) 
+            
             if tubeParams:
                 if 'bool' in tubeParams:  # backward compatible with pre-0.4
                     tubeParams['visible'] = tubeParams.pop('bool')
@@ -165,9 +170,7 @@ class ModuleObj(SuperClass):
                       f'generated: {self._manual_text}')
             
             
-            # set data object attributes from datakey list. 
-            for key in self.keys:
-                setattr(self, key, eval(key))      
+     
             
             if self.modulefile is None:
                 self.modulefile = os.path.join('objects',

--- a/docs/sphinx/source/whatsnew/pending.rst
+++ b/docs/sphinx/source/whatsnew/pending.rst
@@ -7,22 +7,27 @@ Bugfix Release  ...
 
 API Changes
 ~~~~~~~~~~~~
-* New input parameter to :py:class:`~bifacial_radiance.ModuleObj and :py:class:`~bifacial_radiance.RadianceObj.makeModule`:  `glassEdge`.  If :py:class:`~bifacial_radiance.RadianceObj.makeModule` `glass` = True, then this extends the glass past the absorber edge by this total amount (half in each x and y direction). Default 10mm.
-* Module glass thickness can be changed. In :py:class:`~bifacial_radiance.RadianceObj.makeModule`, if `glass` = True, then setting the `z` parameter will indicate the total (front + back) glass thickness with the 1mm absorber in the middle.  The default is z = 10mm.
+* New input parameter to :py:class:`~bifacial_radiance.ModuleObj and :py:func:`~bifacial_radiance.RadianceObj.makeModule`:  `glassEdge`.  If :py:class:`~bifacial_radiance.RadianceObj.makeModule` `glass` = True, then this extends the glass past the absorber edge by this total amount (half in each x and y direction). Default 10mm.
+* Module glass thickness can be changed. In :py:func:`~bifacial_radiance.RadianceObj.makeModule`, if `glass` = True, then setting the `z` parameter will indicate the total (front + back) glass thickness with the 1mm absorber in the middle.  The default is z = 10mm.
 
 Enhancements
 ~~~~~~~~~~~~
 * Conduct an automated check for proper radiance RAYPATH setting (:issue:`525`)(:pull:`537`)
 
 
+Deprecations
+~~~~~~~~~~~~~~
+* .ini files loaded with :py:func:`bifacial_radiance.load.readconfigurationinputfile` use `azimuth` key instead of `axis_azimuth`  (:issue:`438`)(:pull:`551`)
+
 Bug fixes
 ~~~~~~~~~
 * Fixed a major error with indexing the irradiance conditions with :py:func:`~bifacial_radiance.RadianceObj.gendaylit1axis`. This could result in the trackerdict entry being mismatched from the metdata resource. (:issue:`441`)
 * versioning with setuptools_scm- set fallback_version to bifirad v0.4.3 to prevent crashes if git is not present (:issue:`535`)(:pull:`539`)
+* :py:func:`bifacial_radiance.load.readconfigurationinputfile` now properly handles loading moduleObj parameters from .ini files: `glass`, `glassEdge`, `frameParamsDict`, `omegaParamsDict` (:pull:`551`)
 
 Documentation
 ~~~~~~~~~~~~~~
-* No longer provide a warning message when both `hub_height` and `clearance_height` are passed to :py:class:`~bifacial_radiance.AnalysisObj.moduleAnalysis`  (:pull:`540`)
+* No longer provide a warning message when both `hub_height` and `clearance_height` are passed to :py:func:`~bifacial_radiance.AnalysisObj.moduleAnalysis`  (:pull:`540`)
 * More useful __repr__ output in :py:class:`~bifacial_radiance.AnalysisObj and :py:class:`~bifacial_radiance.MetObj   (:issue:`471`)
 
 Contributors

--- a/tests/ini_1axis.ini
+++ b/tests/ini_1axis.ini
@@ -20,7 +20,7 @@ albedo = 0.3
 nMods = 10
 nRows = 3
 hub_height = 2.0
-axis_azimuth = 180.0
+azimuth = 180.0
 
 [timeControlParamsDict]
 starttime: 2001-01-01_1100

--- a/tests/ini_cell_level_module.ini
+++ b/tests/ini_cell_level_module.ini
@@ -22,7 +22,6 @@ azimuth = 180.0
 tilt = 10.0
 clearance_height = 0.8
 hub_height = 0.9
-axis_azimuth = 180.0
 
 [timeControlParamsDict]
 starttime: 06_21_11_00

--- a/tests/ini_soltec.ini
+++ b/tests/ini_soltec.ini
@@ -49,6 +49,7 @@ xgap: 0.020
 ygap: 0.150
 zgap: 0.100
 glass: True
+glassEdge: 0.02
 
 [cellLevelModuleParamsDict]
 numcellsx: 12

--- a/tests/ini_soltec.ini
+++ b/tests/ini_soltec.ini
@@ -6,7 +6,7 @@ getEPW: True
 simulationname: Demo1
 moduletype: Longi
 rewriteModule: True
-cellLevelModule: False
+cellLevelModule: True
 axisofrotationTorqueTube: False
 torqueTube: True
 tracking: True
@@ -43,10 +43,12 @@ trackerAnglesFile: C:\Users\cdeline\Documents\Python Scripts\Test2.csv
 numpanels: 2
 x: 0.98
 y: 1.980
+z: 0.010
 bifi: 0.90
 xgap: 0.020
 ygap: 0.150
 zgap: 0.100
+glass: True
 
 [cellLevelModuleParamsDict]
 numcellsx: 12
@@ -64,7 +66,7 @@ frame_z: 0.02
 frame_width: 0.02
 nSides_frame: 4
 
-[omegaParams]
+[omegaParamsDict]
 omega_material: Metal_Grey
 x_omega1: 0.05
 mod_overlap: 0.04
@@ -78,13 +80,11 @@ diameter: 0.10
 tubetype: Hex
 
 [analysisParamsDict]
-fullRow: False
 modWanted: 10
 rowWanted: 3
-sensorsy_back: 9
-sensorsy_front: 9
-sensorsx_back: 1
-sensorsx_front: 1
+sensorsy: 9
+sensorsx: 1
+
 
 [Posts]
 spacingPost: 6

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -177,15 +177,20 @@ def test_inifile():
     name = "_test_inifile_module"
     demo = bifacial_radiance.RadianceObj(name)  # Create a RadianceObj 'object'
     module = demo.makeModule(name='test-module', tubeParams=torquetubeParamsDict, cellModule=cellLevelModuleParamsDict,
-                              frameParams=frameParamsDict, omegaParams=omegaParamsDict,
+                              frameParams=frameParamsDict, omegaParams=omegaParamsDict, 
                               **moduleParamsDict)
-    # check that there's framesides, framelegs, mod_adj, verti, tt_adj, 
-    assert module.text.find('genbox Metal_Grey frameside 0.003 1.74 0.03') > 0
-    assert module.text.find('genbox Metal_Grey frameleg 0.047 1.74 0.003 | xform -t -0.515 -0.87 -0.03 -a 1 -t 0 1.74 0') > 0
-    assert module.text.find('genbox Metal_Grey frameleg 0.936 0.05 0.003 | xform -t -0.468 -0.87 -0.03 -a 1 -t 0 1.74 0') > 0
-    assert module.text.find('genbox litesoil verti 0.01 1.5 0.0 | xform -t -0.118 -0.75 -0.03') > 0
-    assert module.text.find('genbox litesoil tt_adj 0.05 1.5 0.01 | xform -t -0.16') > 0
-    assert module.text.find('genbox litesoil mod_adj 0.1 1.5 0.01 | xform -t 0.01799') > 0
+    # check that there's a cellPVmodule, torque tube, framesides, framelegs, mod_adj, verti, tt_adj,
+    assert module.glass == True
+    assert module.glassEdge == 0.02
+    assert module.text.find('genbox black cellPVmodule 0.15 0.15 0.001 | xform -t -1.375 -1.37499') > 0
+    assert module.text.find('genbox Metal_Grey hextube1a 2.94 0.05 0.0866') > 0
+    assert module.text.find('genbox Metal_Grey frameside 0.003 1.29') > 0
+    assert module.text.find('genbox Metal_Grey frameleg 0.017 1.29') > 0
+    assert module.text.find('genbox Metal_Grey frameside 2.894 0.003 0.017') > 0
+    assert module.text.find('genbox Metal_Grey mod_adj 0.05 1.5 0.009 | xform -t 1.41 -0.75 0.1359') > 0
+    assert module.text.find('genbox Metal_Grey verti 0.009 1.5 0.1 | xform -t 1.451 -0.75 0.0449') > 0
+    assert module.text.find('genbox Metal_Grey tt_adj 0.01 1.5 0.009 | xform -t 1.46 -0.75 0.0449') > 0
+    
     
     
     

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -25,7 +25,7 @@ try:
 except:
     pass
 
-#TESTDIR = os.path.dirname(__file__)  # this folder
+TESTDIR = os.path.dirname(__file__)  # this folder
 
 cellParams = {'xcell':0.156, 'ycell':0.156, 'numcellsx':6, 'numcellsy':10,  
                'xcellgap':0.02, 'ycellgap':0.02}
@@ -164,5 +164,29 @@ def test_GlassModule():
     module = demo.makeModule(name='test-module', glass=True, x=1, y=2, z=0.005, glassEdge=0.02) 
     assert module.text == '! genbox black test-module 1 2 0.001 | xform -t -0.5 -1.0 0 -a 1 -t 0 2.0' +\
         ' 0\r\n! genbox stock_glass test-module_Glass 1.02 2.02 0.005 | xform -t -0.51 -1.01 -0.0025 -a 1 -t 0 2.0 0'
+
+def test_inifile():
+    # test loading a module from a simulation .ini file
+    INIFILE = os.path.join(TESTDIR, "ini_soltec.ini")
+
+    (simulationParamsDict, sceneParamsDict, timeControlParamsDict, moduleParamsDict, trackingParamsDict, 
+     torquetubeParamsDict, analysisParamsDict, cellLevelModuleParamsDict, frameParamsDict, 
+     omegaParamsDict)= bifacial_radiance.load.readconfigurationinputfile(inifile=INIFILE)
+    
+    simulationParamsDict['testfolder'] = TESTDIR
+    name = "_test_inifile_module"
+    demo = bifacial_radiance.RadianceObj(name)  # Create a RadianceObj 'object'
+    module = demo.makeModule(name='test-module', tubeParams=torquetubeParamsDict, cellModule=cellLevelModuleParamsDict,
+                              frameParams=frameParamsDict, omegaParams=omegaParamsDict,
+                              **moduleParamsDict)
+    # check that there's framesides, framelegs, mod_adj, verti, tt_adj, 
+    assert module.text.find('genbox Metal_Grey frameside 0.003 1.74 0.03') > 0
+    assert module.text.find('genbox Metal_Grey frameleg 0.047 1.74 0.003 | xform -t -0.515 -0.87 -0.03 -a 1 -t 0 1.74 0') > 0
+    assert module.text.find('genbox Metal_Grey frameleg 0.936 0.05 0.003 | xform -t -0.468 -0.87 -0.03 -a 1 -t 0 1.74 0') > 0
+    assert module.text.find('genbox litesoil verti 0.01 1.5 0.0 | xform -t -0.118 -0.75 -0.03') > 0
+    assert module.text.find('genbox litesoil tt_adj 0.05 1.5 0.01 | xform -t -0.16') > 0
+    assert module.text.find('genbox litesoil mod_adj 0.1 1.5 0.01 | xform -t 0.01799') > 0
+    
+    
     
     


### PR DESCRIPTION
load.py was ignoring some makeModule inputs, including `glass`, `glassEdge`, `frameParamsDict` and `omegaParamsDict`.  Also, `axis_azimuth` had been deprecated, but was still being loaded by load.py.  This fixes all of that.